### PR TITLE
Unfolding should be after mulaw decoding

### DIFF
--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -223,13 +223,14 @@ class WaveRNN(nn.Module):
         output = output.cpu().numpy()
         output = output.astype(np.float64)
 
+        if mu_law:
+            for i, o in enumerate(output):
+                output[i] = decode_mu_law(output[i], self.n_classes, False)
+
         if batched:
             output = self.xfade_and_unfold(output, target, overlap)
         else:
             output = output[0]
-
-        if mu_law :
-            output = decode_mu_law(output, self.n_classes, False)
 
         # Fade-out at the end to avoid signal cutting out suddenly
         fade_out = np.linspace(1, 0, 20 * self.hop_length)


### PR DESCRIPTION
In unfolding algorithm, what we compute should be the original wave but not the mulaw compression. So we shall move the mulaw decoding function ahead of the unfolding function and that would make the results of unfolding more natural.

Signed-off-by: begeekmyfriend <begeekmyfriend@gmail.com>