### PR TITLE
Added CPU support, other fixes too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # PyCharm files
 .idea
 
+# Mac files
+.DS_Store
+
 # Environments
 .env
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,44 @@
+# PyCharm files
 .idea
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Jupyter Notebook
+.ipynb_checkpoints

--- a/gen_tacotron.py
+++ b/gen_tacotron.py
@@ -8,7 +8,7 @@ import argparse
 from utils.text import text_to_sequence
 from utils.display import save_attention, simple_table
 
-if __name__ == "__main__" :
+if __name__ == "__main__":
 
     # Parse Arguments
     parser = argparse.ArgumentParser(description='TTS Generator')
@@ -73,10 +73,10 @@ if __name__ == "__main__" :
     tts_restore_path = weights_path if weights_path else paths.tts_latest_weights
     tts_model.restore(tts_restore_path)
 
-    if input_text :
+    if input_text:
         inputs = [text_to_sequence(input_text.strip(), hp.tts_cleaner_names)]
-    else :
-        with open('sentences.txt') as f :
+    else:
+        with open('sentences.txt') as f:
             inputs = [text_to_sequence(l.strip(), hp.tts_cleaner_names) for l in f]
 
     voc_k = voc_model.get_step() // 1000
@@ -89,17 +89,17 @@ if __name__ == "__main__" :
                   ('Target Samples', target if batched else 'N/A'),
                   ('Overlap Samples', overlap if batched else 'N/A')])
 
-    for i, x in enumerate(inputs, 1) :
+    for i, x in enumerate(inputs, 1):
 
         print(f'\n| Generating {i}/{len(inputs)}')
         _, m, attention = tts_model.generate(x)
 
-        if input_text :
+        if input_text:
             save_path = f'{paths.tts_output}__input_{input_text[:10]}_{tts_k}k.wav'
-        else :
+        else:
             save_path = f'{paths.tts_output}{i}_batched{str(batched)}_{tts_k}k.wav'
 
-        if save_attn : save_attention(attention, save_path)
+        if save_attn: save_attention(attention, save_path)
 
         m = torch.tensor(m).unsqueeze(0)
         m = (m + 4) / 8

--- a/gen_wavernn.py
+++ b/gen_wavernn.py
@@ -7,13 +7,13 @@ import torch
 import argparse
 
 
-def gen_testset(model, test_set, samples, batched, target, overlap, save_path) :
+def gen_testset(model, test_set, samples, batched, target, overlap, save_path):
 
     k = model.get_step() // 1000
 
     for i, (m, x) in enumerate(test_set, 1):
 
-        if i > samples : break
+        if i > samples: break
 
         print('\n| Generating: %i/%i' % (i, samples))
 
@@ -21,9 +21,9 @@ def gen_testset(model, test_set, samples, batched, target, overlap, save_path) :
 
         bits = 16 if hp.voc_mode == 'MOL' else hp.bits
 
-        if hp.mu_law and hp.voc_mode != 'MOL' :
+        if hp.mu_law and hp.voc_mode != 'MOL':
             x = decode_mu_law(x, 2**bits, from_labels=True)
-        else :
+        else:
             x = label_2_float(x, bits)
 
         save_wav(x, f'{save_path}{k}k_steps_{i}_target.wav')
@@ -34,7 +34,7 @@ def gen_testset(model, test_set, samples, batched, target, overlap, save_path) :
         _ = model.generate(m, save_str, batched, target, overlap, hp.mu_law)
 
 
-def gen_from_file(model, load_path, save_path, batched, target, overlap) :
+def gen_from_file(model, load_path, save_path, batched, target, overlap):
 
     k = model.get_step() // 1000
     file_name = load_path.split('/')[-1]
@@ -107,9 +107,9 @@ if __name__ == "__main__":
 
     _, test_set = get_vocoder_datasets(paths.data, 1, gta)
 
-    if file :
+    if file:
         gen_from_file(model, file, paths.voc_output, batched, target, overlap)
-    else :
+    else:
         gen_testset(model, test_set, samples, batched, target, overlap, paths.voc_output)
 
     print('\n\nExiting...\n')

--- a/gen_wavernn.py
+++ b/gen_wavernn.py
@@ -62,6 +62,7 @@ if __name__ == "__main__":
     parser.add_argument('--file', '-f', type=str, help='[string/path] for testing a wav outside dataset')
     parser.add_argument('--weights', '-w', type=str, help='[string/path] checkpoint file to load weights from')
     parser.add_argument('--gta', '-g', dest='use_gta', action='store_true', help='Generate from GTA testset')
+    parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
 
     parser.set_defaults(batched=hp.voc_gen_batched)
     parser.set_defaults(samples=hp.voc_gen_at_checkpoint)
@@ -80,6 +81,12 @@ if __name__ == "__main__":
     file = args.file
     gta = args.gta
 
+    if not args.force_cpu and torch.cuda.is_available():
+        device = torch.device('cuda')
+    else:
+        device = torch.device('cpu')
+    print('Using device:', device)
+
     print('\nInitialising Model...\n')
 
     model = WaveRNN(rnn_dims=hp.voc_rnn_dims,
@@ -93,7 +100,7 @@ if __name__ == "__main__":
                     res_blocks=hp.voc_res_blocks,
                     hop_length=hp.hop_length,
                     sample_rate=hp.sample_rate,
-                    mode=hp.voc_mode).cuda()
+                    mode=hp.voc_mode).to(device)
 
     paths = Paths(hp.data_path, hp.voc_model_id, hp.tts_model_id)
 

--- a/models/deepmind_version.py
+++ b/models/deepmind_version.py
@@ -4,8 +4,8 @@ import torch.nn.functional as F
 from utils.display import *
 from utils.dsp import *
 
-class WaveRNN(nn.Module) :
-    def __init__(self, hidden_size=896, quantisation=256) :
+class WaveRNN(nn.Module):
+    def __init__(self, hidden_size=896, quantisation=256):
         super(WaveRNN, self).__init__()
         
         self.hidden_size = hidden_size
@@ -33,7 +33,7 @@ class WaveRNN(nn.Module) :
         self.num_params()
 
         
-    def forward(self, prev_y, prev_hidden, current_coarse) :
+    def forward(self, prev_y, prev_hidden, current_coarse):
         
         # Main matmul - the projection is split 3 ways
         R_hidden = self.R(prev_hidden)
@@ -71,9 +71,9 @@ class WaveRNN(nn.Module) :
         return out_coarse, out_fine, hidden
     
         
-    def generate(self, seq_len) :
+    def generate(self, seq_len):
         
-        with torch.no_grad() :
+        with torch.no_grad():
             
             # First split up the biases for the gates 
             b_coarse_u, b_fine_u = torch.split(self.bias_u, self.split_size)
@@ -94,7 +94,7 @@ class WaveRNN(nn.Module) :
             start = time.time()
 
             # Loop for generation
-            for i in range(seq_len) :
+            for i in range(seq_len):
 
                 # Split into two hidden states
                 hidden_coarse, hidden_fine = \
@@ -162,10 +162,10 @@ class WaveRNN(nn.Module) :
         
         return output, coarse, fine
 
-    def init_hidden(self, batch_size=1) :
+    def init_hidden(self, batch_size=1):
         return torch.zeros(batch_size, self.hidden_size).cuda()
     
-    def num_params(self) :
+    def num_params(self):
         parameters = filter(lambda p: p.requires_grad, self.parameters())
         parameters = sum([np.prod(p.size()) for p in parameters]) / 1_000_000
         print('Trainable Parameters: %.3f million' % parameters)

--- a/models/deepmind_version.py
+++ b/models/deepmind_version.py
@@ -71,17 +71,8 @@ class WaveRNN(nn.Module):
         return out_coarse, out_fine, hidden
     
         
-    def generate(self, seq_len, device=None):
-        """Generates audio from mel spectrograms.
-        Args:
-            device:  The device to use for the generation. If `None`, prefers GPU over CPU.
-        """
-        if device is None:
-            # Prefer CUDA if its available for faster inference
-            device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        
-        # Place the model on the desired device
-        self.to(device)
+    def generate(self, seq_len):
+        device = next(self.parameters()).device  # use same device as parameters
 
         with torch.no_grad():
             
@@ -94,11 +85,11 @@ class WaveRNN(nn.Module):
             c_outputs, f_outputs = [], []
 
             # Some initial inputs
-            out_coarse = torch.tensor([0], dtype=long, device=device)
-            out_fine = torch.tensor([0], dtype=long, device=device)
+            out_coarse = torch.tensor([0], dtype=torch.long, device=device)
+            out_fine = torch.tensor([0], dtype=torch.long, device=device)
 
             # We'll meed a hidden state
-            hidden = self.get_initial_hidden(device=device)
+            hidden = self.get_initial_hidden()
 
             # Need a clock for display
             start = time.time()
@@ -172,16 +163,9 @@ class WaveRNN(nn.Module):
         
         return output, coarse, fine
 
-    def get_initial_hidden(self, batch_size=1, device=None):
-        """Returns an initial hiden state.
-        Args:
-            device:  The device to use for the generation. If `None`, prefers GPU over CPU.
-        """
-        if device is None:
-            # Prefer CUDA if its available for faster inference
-            device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        
-        return torch.zeros(batch_size, self.hidden_size, device)
+    def get_initial_hidden(self, batch_size=1):
+        device = next(self.parameters()).device  # use same device as parameters
+        return torch.zeros(batch_size, self.hidden_size, device=device)
     
     def num_params(self):
         parameters = filter(lambda p: p.requires_grad, self.parameters())

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -117,8 +117,8 @@ class WaveRNN(nn.Module):
         self.num_params()
 
     def forward(self, x, mels):
-        device = x.device
-        assert x.device == mels.device
+        device = next(self.parameters()).device  # use same device as parameters
+        
         self.step += 1
         bsize = x.size(0)
         h1 = torch.zeros(1, bsize, self.rnn_dims, device=device)
@@ -149,21 +149,8 @@ class WaveRNN(nn.Module):
         x = F.relu(self.fc2(x))
         return self.fc3(x)
 
-    def generate(self, mels, save_path, batched, target, overlap, mu_law, device=None):
-        """Generates audio from mel spectrograms.
-        Args:
-            device:  The device to use for the generation. If specified, should match `mels.device`
-                if `mels` is a Tensor. If `None` AND `mels` is not a tensor, it will prefer GPU over CPU.
-        """
-        if device is None:
-            if torch.is_tensor(mels):
-                device = mels.device
-            else:
-                # Prefer CUDA if its available for faster inference
-                device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        else:
-            if device is not None and torch.is_tensor(mels) and device != mels.device:
-                raise ValueError('`mels` was a Tensor, but the specified device was different!')
+    def generate(self, mels, save_path, batched, target, overlap, mu_law):
+        device = next(self.parameters()).device  # use same device as parameters
 
         mu_law = mu_law if self.mode == 'RAW' else False
 

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -93,11 +93,11 @@ class WaveRNN(nn.Module):
         super().__init__()
         self.mode = mode
         self.pad = pad
-        if self.mode == 'RAW' :
+        if self.mode == 'RAW':
             self.n_classes = 2 ** bits
-        elif self.mode == 'MOL' :
+        elif self.mode == 'MOL':
             self.n_classes = 30
-        else :
+        else:
             RuntimeError("Unknown model mode value - ", self.mode)
 
         self.rnn_dims = rnn_dims
@@ -223,7 +223,7 @@ class WaveRNN(nn.Module):
                     # x = torch.FloatTensor([[sample]]).cuda()
                     x = sample.transpose(0, 1)
 
-                elif self.mode == 'RAW' :
+                elif self.mode == 'RAW':
                     posterior = F.softmax(logits, dim=1)
                     distrib = torch.distributions.Categorical(posterior)
 
@@ -233,7 +233,7 @@ class WaveRNN(nn.Module):
                 else:
                     raise RuntimeError("Unknown model mode value - ", self.mode)
 
-                if i % 100 == 0 : self.gen_display(i, seq_len, b_size, start)
+                if i % 100 == 0: self.gen_display(i, seq_len, b_size, start)
 
         output = torch.stack(output).transpose(0, 1)
         output = output.cpu().numpy()
@@ -244,7 +244,7 @@ class WaveRNN(nn.Module):
         else:
             output = output[0]
 
-        if mu_law :
+        if mu_law:
             output = decode_mu_law(output, self.n_classes, False)
 
         # Fade-out at the end to avoid signal cutting out suddenly
@@ -401,7 +401,7 @@ class WaveRNN(nn.Module):
     def get_step(self):
         return self.step.data.item()
 
-    def checkpoint(self, path) :
+    def checkpoint(self, path):
         k_steps = self.get_step() // 1000
         self.save(f'{path}/checkpoint_{k_steps}k_steps.pyt')
 
@@ -410,7 +410,7 @@ class WaveRNN(nn.Module):
             print(msg, file=f)
 
     def restore(self, path):
-        if not os.path.exists(path) :
+        if not os.path.exists(path):
             print('\nNew WaveRNN Training Session...\n')
             self.save(path)
         else:

--- a/preprocess.py
+++ b/preprocess.py
@@ -19,21 +19,21 @@ extension = args.extension
 path = args.path
 
 
-def convert_file(path) :
+def convert_file(path):
     y = load_wav(path)
     peak = np.abs(y).max()
     if hp.peak_norm or peak > 1.0:
         y /= peak
     mel = melspectrogram(y)
-    if hp.voc_mode == 'RAW' :
+    if hp.voc_mode == 'RAW':
         quant = encode_mu_law(y, mu=2**hp.bits) if hp.mu_law else float_2_label(y, bits=hp.bits)
-    elif hp.voc_mode == 'MOL' :
+    elif hp.voc_mode == 'MOL':
         quant = float_2_label(y, bits=16)
 
     return mel.astype(np.float32), quant.astype(np.int64)
 
 
-def process_wav(path) :
+def process_wav(path):
     id = path.split('/')[-1][:-4]
     m, x = convert_file(path)
     np.save(f'{paths.mel}{id}.npy', m, allow_pickle=False)
@@ -46,14 +46,14 @@ paths = Paths(hp.data_path, hp.voc_model_id, hp.tts_model_id)
 
 print(f'\n{len(wav_files)} {extension[1:]} files found in "{path}"\n')
 
-if len(wav_files) == 0 :
+if len(wav_files) == 0:
 
     print('Please point wav_path in hparams.py to your dataset,')
     print('or use the --path option.\n')
 
-else :
+else:
 
-    if not hp.ignore_tts :
+    if not hp.ignore_tts:
 
         text_dict = ljspeech(path)
 

--- a/quick_start.py
+++ b/quick_start.py
@@ -31,7 +31,6 @@ if __name__ == "__main__":
     parser.add_argument('--target', '-t', type=int, help='[int] number of samples in each batch index')
     parser.add_argument('--overlap', '-o', type=int, help='[int] number of crossover samples')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
-    parser.set_defaults(force_cpu=False)
     parser.set_defaults(batched=hp.voc_gen_batched)
     parser.set_defaults(target=hp.voc_target)
     parser.set_defaults(overlap=hp.voc_overlap)
@@ -49,7 +48,7 @@ if __name__ == "__main__":
         device = torch.device('cuda')
     else:
         device = torch.device('cpu')
-
+    print('Using device:', device)
 
     print('\nInitialising WaveRNN Model...\n')
 
@@ -108,18 +107,18 @@ if __name__ == "__main__":
     for i, x in enumerate(inputs, 1):
 
         print(f'\n| Generating {i}/{len(inputs)}')
-        _, m, attention = tts_model.generate(x, device=device)
+        _, m, attention = tts_model.generate(x)
 
         if input_text:
             save_path = f'quick_start/__input_{input_text[:10]}_{tts_k}k.wav'
         else:
             save_path = f'quick_start/{i}_batched{str(batched)}_{tts_k}k.wav'
 
-        save_attention(attention, save_path)
+        # save_attention(attention, save_path)
 
         m = torch.tensor(m).unsqueeze(0)
         m = (m + 4) / 8
 
-        voc_model.generate(m, save_path, batched, hp.voc_target, hp.voc_overlap, hp.mu_law, device=device)
+        voc_model.generate(m, save_path, batched, hp.voc_target, hp.voc_overlap, hp.mu_law)
 
     print('\n\nDone.\n')

--- a/quick_start.py
+++ b/quick_start.py
@@ -21,7 +21,7 @@ zip_ref.extractall('quick_start/tts_weights/')
 zip_ref.close()
 
 
-if __name__ == "__main__" :
+if __name__ == "__main__":
 
     # Parse Arguments
     parser = argparse.ArgumentParser(description='TTS Generator')
@@ -88,10 +88,10 @@ if __name__ == "__main__" :
 
     tts_model.restore('quick_start/tts_weights/latest_weights.pyt')
 
-    if input_text :
+    if input_text:
         inputs = [text_to_sequence(input_text.strip(), hp.tts_cleaner_names)]
-    else :
-        with open('sentences.txt') as f :
+    else:
+        with open('sentences.txt') as f:
             inputs = [text_to_sequence(l.strip(), hp.tts_cleaner_names) for l in f]
 
     voc_k = voc_model.get_step() // 1000
@@ -105,14 +105,14 @@ if __name__ == "__main__" :
                   ('Target Samples', target if batched else 'N/A'),
                   ('Overlap Samples', overlap if batched else 'N/A')])
 
-    for i, x in enumerate(inputs, 1) :
+    for i, x in enumerate(inputs, 1):
 
         print(f'\n| Generating {i}/{len(inputs)}')
         _, m, attention = tts_model.generate(x, device=device)
 
-        if input_text :
+        if input_text:
             save_path = f'quick_start/__input_{input_text[:10]}_{tts_k}k.wav'
-        else :
+        else:
             save_path = f'quick_start/{i}_batched{str(batched)}_{tts_k}k.wav'
 
         save_attention(attention, save_path)

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -10,7 +10,7 @@ from models.tacotron import Tacotron
 import argparse
 
 
-def np_now(x) : return x.detach().cpu().numpy()
+def np_now(x): return x.detach().cpu().numpy()
 
 
 def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
@@ -42,7 +42,7 @@ def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
 
             loss.backward()
 
-            if hp.tts_clip_grad_norm :
+            if hp.tts_clip_grad_norm:
                 torch.nn.utils.clip_grad_norm_(model.parameters(), hp.tts_clip_grad_norm)
 
             optimizer.step()
@@ -54,10 +54,10 @@ def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
 
             avg_loss = running_loss / i
 
-            if step % hp.tts_checkpoint_every == 0 :
+            if step % hp.tts_checkpoint_every == 0:
                 model.checkpoint(paths.tts_checkpoints)
 
-            if attn_example in ids :
+            if attn_example in ids:
                 idx = ids.index(attn_example)
                 save_attention(attention[idx][:, :160], f'{paths.tts_attention}{step}')
                 save_spectrogram(np_now(m2_hat[idx]), f'{paths.tts_mel_plot}{step}', 600)
@@ -78,11 +78,11 @@ def create_gta_features(model, train_set, save_path):
 
         x, mels = x.cuda(), mels.cuda()
 
-        with torch.no_grad() : _, gta, _ = model(x, mels)
+        with torch.no_grad(): _, gta, _ = model(x, mels)
 
         gta = gta.cpu().numpy()
 
-        for j in range(len(ids)) :
+        for j in range(len(ids)):
             mel = gta[j][:, :mel_lens[j]]
             mel = (mel + 4) / 8
             id = ids[j]
@@ -93,7 +93,7 @@ def create_gta_features(model, train_set, save_path):
         stream(msg)
 
 
-if __name__ == "__main__" :
+if __name__ == "__main__":
 
     # Parse Arguments
     parser = argparse.ArgumentParser(description='Train Tacotron TTS')
@@ -132,13 +132,13 @@ if __name__ == "__main__" :
 
     current_step = model.get_step()
 
-    if not force_gta :
+    if not force_gta:
 
-        for session in hp.tts_schedule :
+        for session in hp.tts_schedule:
 
             r, lr, max_step, batch_size = session
 
-            if current_step < max_step :
+            if current_step < max_step:
 
                 train_set, attn_example = get_tts_dataset(paths.data, batch_size, r)
 

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -30,10 +30,10 @@ def voc_train_loop(model, loss_func, optimiser, train_set, test_set, lr, total_s
 
             y_hat = model(x, m)
 
-            if model.mode == 'RAW' :
+            if model.mode == 'RAW':
                 y_hat = y_hat.transpose(1, 2).unsqueeze(-1)
 
-            elif model.mode == 'MOL' :
+            elif model.mode == 'MOL':
                 y = y.float()
 
             y = y.unsqueeze(-1)
@@ -52,7 +52,7 @@ def voc_train_loop(model, loss_func, optimiser, train_set, test_set, lr, total_s
             step = model.get_step()
             k = step // 1000
 
-            if step % hp.voc_checkpoint_every == 0 :
+            if step % hp.voc_checkpoint_every == 0:
                 gen_testset(model, test_set, hp.voc_gen_at_checkpoint, hp.voc_gen_batched,
                             hp.voc_target, hp.voc_overlap, paths.voc_output)
                 model.checkpoint(paths.voc_checkpoints)
@@ -65,7 +65,7 @@ def voc_train_loop(model, loss_func, optimiser, train_set, test_set, lr, total_s
         print(' ')
 
 
-if __name__ == "__main__" :
+if __name__ == "__main__":
 
     # Parse Arguments
     parser = argparse.ArgumentParser(description='Train WaveRNN Vocoder')

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -74,7 +74,6 @@ if __name__ == "__main__":
     parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
     parser.add_argument('--gta', '-g', action='store_true', help='train wavernn on GTA features')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
-    parser.set_defaults(force_cpu=False)
     parser.set_defaults(lr=hp.voc_lr)
     parser.set_defaults(batch_size=hp.voc_batch_size)
     args = parser.parse_args()
@@ -88,6 +87,7 @@ if __name__ == "__main__":
         device = torch.device('cuda')
     else:
         device = torch.device('cpu')
+    print('Using device:', device)
 
     print('\nInitialising Model...\n')
 

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -1,5 +1,6 @@
 import time
 import numpy as np
+import torch
 from torch import optim
 import torch.nn.functional as F
 from utils.display import stream, simple_table
@@ -12,7 +13,7 @@ from utils.paths import Paths
 import argparse
 
 
-def voc_train_loop(model, loss_func, optimiser, train_set, test_set, lr, total_steps):
+def voc_train_loop(model, loss_func, optimiser, train_set, test_set, lr, total_steps, device):
 
     for p in optimiser.param_groups: p['lr'] = lr
 
@@ -25,7 +26,7 @@ def voc_train_loop(model, loss_func, optimiser, train_set, test_set, lr, total_s
         running_loss = 0.
 
         for i, (x, y, m) in enumerate(train_set, 1):
-            x, m, y = x.cuda(), m.cuda(), y.cuda()
+            x, m, y = x.to(device), m.to(device), y.to(device)
 
             y_hat = model(x, m)
 
@@ -72,6 +73,8 @@ if __name__ == "__main__" :
     parser.add_argument('--batch_size', '-b', type=int, help='[int] override hparams.py batch size')
     parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
     parser.add_argument('--gta', '-g', action='store_true', help='train wavernn on GTA features')
+    parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
+    parser.set_defaults(force_cpu=False)
     parser.set_defaults(lr=hp.voc_lr)
     parser.set_defaults(batch_size=hp.voc_batch_size)
     args = parser.parse_args()
@@ -80,6 +83,11 @@ if __name__ == "__main__" :
     force_train = args.force_train
     train_gta = args.gta
     lr = args.lr
+    
+    if not args.force_cpu and torch.cuda.is_available():
+        device = torch.device('cuda')
+    else:
+        device = torch.device('cpu')
 
     print('\nInitialising Model...\n')
 
@@ -95,7 +103,7 @@ if __name__ == "__main__" :
                         res_blocks=hp.voc_res_blocks,
                         hop_length=hp.hop_length,
                         sample_rate=hp.sample_rate,
-                        mode=hp.voc_mode).cuda()
+                        mode=hp.voc_mode).to(device)
 
     # Check to make sure the hop length is correctly factorised
     assert np.cumprod(hp.voc_upsample_factors)[-1] == hp.hop_length
@@ -118,7 +126,7 @@ if __name__ == "__main__" :
 
     loss_func = F.cross_entropy if voc_model.mode == 'RAW' else discretized_mix_logistic_loss
 
-    voc_train_loop(voc_model, loss_func, optimiser, train_set, test_set, lr, total_steps)
+    voc_train_loop(voc_model, loss_func, optimiser, train_set, test_set, lr, total_steps, device)
 
     print('Training Complete.')
     print('To continue training increase voc_total_steps in hparams.py or use --force_train')

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -13,26 +13,26 @@ from utils.text import text_to_sequence
 ###################################################################################
 
 
-class VocoderDataset(Dataset) :
-    def __init__(self, ids, path, train_gta=False) :
+class VocoderDataset(Dataset):
+    def __init__(self, ids, path, train_gta=False):
         self.metadata = ids
         self.mel_path = f'{path}gta/' if train_gta else f'{path}mel/'
         self.quant_path = f'{path}quant/'
 
 
-    def __getitem__(self, index) :
+    def __getitem__(self, index):
         id = self.metadata[index]
         m = np.load(f'{self.mel_path}{id}.npy')
         x = np.load(f'{self.quant_path}{id}.npy')
         return m, x
 
-    def __len__(self) :
+    def __len__(self):
         return len(self.metadata)
 
 
-def get_vocoder_datasets(path, batch_size, train_gta) :
+def get_vocoder_datasets(path, batch_size, train_gta):
 
-    with open(f'{path}dataset.pkl', 'rb') as f :
+    with open(f'{path}dataset.pkl', 'rb') as f:
         dataset = pickle.load(f)
 
     dataset_ids = [x[0] for x in dataset]
@@ -85,7 +85,7 @@ def collate_vocoder(batch):
 
     x = label_2_float(x.float(), bits)
 
-    if hp.voc_mode == 'MOL' :
+    if hp.voc_mode == 'MOL':
         y = label_2_float(y.float(), bits)
 
     return x, y, mels
@@ -96,16 +96,16 @@ def collate_vocoder(batch):
 ###################################################################################
 
 
-def get_tts_dataset(path, batch_size, r) :
+def get_tts_dataset(path, batch_size, r):
 
-    with open(f'{path}dataset.pkl', 'rb') as f :
+    with open(f'{path}dataset.pkl', 'rb') as f:
         dataset = pickle.load(f)
 
     dataset_ids = []
     mel_lengths = []
 
-    for (id, len) in dataset :
-        if len <= hp.tts_max_mel_len :
+    for (id, len) in dataset:
+        if len <= hp.tts_max_mel_len:
             dataset_ids += [id]
             mel_lengths += [len]
 
@@ -116,11 +116,11 @@ def get_tts_dataset(path, batch_size, r) :
 
     sampler = None
 
-    if hp.tts_bin_lengths :
+    if hp.tts_bin_lengths:
         sampler = BinnedLengthSampler(mel_lengths, batch_size, batch_size * 3)
 
     train_set = DataLoader(train_dataset,
-                           collate_fn=lambda batch : collate_tts(batch, r),
+                           collate_fn=lambda batch: collate_tts(batch, r),
                            batch_size=batch_size,
                            sampler=sampler,
                            num_workers=1,
@@ -135,7 +135,7 @@ def get_tts_dataset(path, batch_size, r) :
 
 
 class TTSDataset(Dataset):
-    def __init__(self, path, dataset_ids, text_dict) :
+    def __init__(self, path, dataset_ids, text_dict):
         self.path = path
         self.metadata = dataset_ids
         self.text_dict = text_dict
@@ -151,11 +151,11 @@ class TTSDataset(Dataset):
         return len(self.metadata)
 
 
-def pad1d(x, max_len) :
+def pad1d(x, max_len):
     return np.pad(x, (0, max_len - len(x)), mode='constant')
 
 
-def pad2d(x, max_len) :
+def pad2d(x, max_len):
     return np.pad(x, ((0, 0), (0, max_len - x.shape[-1])), mode='constant')
 
 
@@ -195,7 +195,7 @@ class BinnedLengthSampler(Sampler):
 
     def __iter__(self):
         # Need to change to numpy since there's a bug in random.shuffle(tensor)
-        # TODO : Post an issue on pytorch repo
+        # TODO: Post an issue on pytorch repo
         idx = self.idx.numpy()
         bins = []
 
@@ -207,7 +207,7 @@ class BinnedLengthSampler(Sampler):
         random.shuffle(bins)
         binned_idx = np.stack(bins).reshape(-1)
 
-        if len(binned_idx) < len(idx) :
+        if len(binned_idx) < len(idx):
             last_bin = idx[len(binned_idx):]
             random.shuffle(last_bin)
             binned_idx = np.concatenate([binned_idx, last_bin])

--- a/utils/display.py
+++ b/utils/display.py
@@ -12,18 +12,18 @@ def progbar(i, n, size=16):
     return bar
 
 
-def stream(message) :
+def stream(message):
     sys.stdout.write(f"\r{message}")
 
 
-def simple_table(item_tuples) :
+def simple_table(item_tuples):
 
     border_pattern = '+---------------------------------------'
     whitespace = '                                            '
 
     headings, cells, = [], []
 
-    for item in item_tuples :
+    for item in item_tuples:
 
         heading, cell = str(item[0]), str(item[1])
 
@@ -35,9 +35,9 @@ def simple_table(item_tuples) :
         pad_left = pad[:len(pad)//2]
         pad_right = pad[len(pad)//2:]
 
-        if pad_head :
+        if pad_head:
             heading = pad_left + heading + pad_right
-        else :
+        else:
             cell = pad_left + cell + pad_right
 
         headings += [heading]
@@ -45,7 +45,7 @@ def simple_table(item_tuples) :
 
     border, head, body = '', '', ''
 
-    for i in range(len(item_tuples)) :
+    for i in range(len(item_tuples)):
 
         temp_head = f'| {headings[i]} '
         temp_body = f'| {cells[i]} '
@@ -54,7 +54,7 @@ def simple_table(item_tuples) :
         head += temp_head
         body += temp_body
 
-        if i == len(item_tuples) - 1 :
+        if i == len(item_tuples) - 1:
             head += '|'
             body += '|'
             border += '+'
@@ -67,35 +67,35 @@ def simple_table(item_tuples) :
     print(' ')
 
 
-def time_since(started) :
+def time_since(started):
     elapsed = time.time() - started
     m = int(elapsed // 60)
     s = int(elapsed % 60)
-    if m >= 60 :
+    if m >= 60:
         h = int(m // 60)
         m = m % 60
         return f'{h}h {m}m {s}s'
-    else :
+    else:
         return f'{m}m {s}s'
 
 
-def save_attention(attn, path) :
+def save_attention(attn, path):
     fig = plt.figure(figsize=(12, 6))
     plt.imshow(attn.T, interpolation='nearest', aspect='auto')
     fig.savefig(f'{path}.png', bbox_inches='tight')
     plt.close(fig)
 
 
-def save_spectrogram(M, path, length=None) :
+def save_spectrogram(M, path, length=None):
     M = np.flip(M, axis=0)
-    if length : M = M[:, :length]
+    if length: M = M[:, :length]
     fig = plt.figure(figsize=(12, 6))
     plt.imshow(M, interpolation='nearest', aspect='auto')
     fig.savefig(f'{path}.png', bbox_inches='tight')
     plt.close(fig)
 
 
-def plot(array) : 
+def plot(array): 
     fig = plt.figure(figsize=(30, 5))
     ax = fig.add_subplot(111)
     ax.xaxis.label.set_color('grey')
@@ -107,7 +107,7 @@ def plot(array) :
     plt.plot(array)
 
 
-def plot_spec(M) :
+def plot_spec(M):
     M = np.flip(M, axis=0)
     plt.figure(figsize=(18,4))
     plt.imshow(M, interpolation='nearest', aspect='auto')

--- a/utils/distribution.py
+++ b/utils/distribution.py
@@ -108,7 +108,7 @@ def sample_from_discretized_mix_logistic(y, log_scale_min=None):
     _, argmax = temp.max(dim=-1)
 
     # (B, T) -> (B, T, nr_mix)
-    one_hot = to_one_hot(argmax, nr_mix)
+    one_hot = F.one_hot(argmax, nr_mix).float()
     # select logistic parameters
     means = torch.sum(y[:, :, nr_mix:2 * nr_mix] * one_hot, dim=-1)
     log_scales = torch.clamp(torch.sum(
@@ -122,11 +122,11 @@ def sample_from_discretized_mix_logistic(y, log_scale_min=None):
 
     return x
 
-
+'''
 def to_one_hot(tensor, n, fill_with=1.):
     # we perform one hot encore with respect to the last axis
     one_hot = torch.FloatTensor(tensor.size() + (n,)).zero_()
     if tensor.is_cuda:
         one_hot = one_hot.cuda()
     one_hot.scatter_(len(tensor.size()), tensor.unsqueeze(-1), fill_with)
-    return one_hot
+    return one_hot'''

--- a/utils/dsp.py
+++ b/utils/dsp.py
@@ -5,35 +5,35 @@ import hparams as hp
 from scipy.signal import lfilter
 
 
-def label_2_float(x, bits) :
+def label_2_float(x, bits):
     return 2 * x / (2**bits - 1.) - 1.
 
 
-def float_2_label(x, bits) :
+def float_2_label(x, bits):
     assert abs(x).max() <= 1.0
     x = (x + 1.) * (2**bits - 1) / 2
     return x.clip(0, 2**bits - 1)
 
-def load_wav(path) :
+def load_wav(path):
     return librosa.load(path, sr=hp.sample_rate)[0]
 
 
-def save_wav(x, path) :
+def save_wav(x, path):
     librosa.output.write_wav(path, x.astype(np.float32), sr=hp.sample_rate)
 
 
-def split_signal(x) :
+def split_signal(x):
     unsigned = x + 2**15
     coarse = unsigned // 256
     fine = unsigned % 256
     return coarse, fine
 
 
-def combine_signal(coarse, fine) :
+def combine_signal(coarse, fine):
     return coarse * 256 + fine - 2**15
 
 
-def encode_16bits(x) :
+def encode_16bits(x):
     return np.clip(x * 2**15, -2**15, 2**15 - 1).astype(np.int16)
 
 
@@ -91,15 +91,15 @@ def de_emphasis(x):
     return lfilter([1], [1, -hp.preemphasis], x)
 
 
-def encode_mu_law(x, mu) :
+def encode_mu_law(x, mu):
     mu = mu - 1
     fx = np.sign(x) * np.log(1 + mu * np.abs(x)) / np.log(1 + mu)
     return np.floor((fx + 1) / 2 * mu + 0.5)
 
 
-def decode_mu_law(y, mu, from_labels=True) :
-    # TODO : get rid of log2 - makes no sense
-    if from_labels : y = label_2_float(y, math.log2(mu))
+def decode_mu_law(y, mu, from_labels=True):
+    # TODO: get rid of log2 - makes no sense
+    if from_labels: y = label_2_float(y, math.log2(mu))
     mu = mu - 1
     x = np.sign(y) / mu * ((1 + mu) ** np.abs(y) - 1)
     return x

--- a/utils/files.py
+++ b/utils/files.py
@@ -1,6 +1,6 @@
 import glob
 
-def get_files(path, extension='.wav') :
+def get_files(path, extension='.wav'):
     filenames = []
     for filename in glob.iglob(f'{path}/**/*{extension}', recursive=True):
         filenames += [filename]

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,8 +1,8 @@
 import os
 
 
-class Paths :
-    def __init__(self, data_path, voc_id, tts_id) :
+class Paths:
+    def __init__(self, data_path, voc_id, tts_id):
         # Data Paths
         self.data = f'{data_path}{voc_id}/'
         self.quant = f'{self.data}quant/'
@@ -24,7 +24,7 @@ class Paths :
         self.tts_mel_plot = f'{self.tts_checkpoints}/mel_plots/'
         self.create_paths()
 
-    def create_paths(self) :
+    def create_paths(self):
         os.makedirs(self.data, exist_ok=True)
         os.makedirs(self.quant, exist_ok=True)
         os.makedirs(self.mel, exist_ok=True)

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -4,7 +4,7 @@ import os
 class Paths :
     def __init__(self, data_path, voc_id, tts_id) :
         # Data Paths
-        self.data = f'{data_path}/{voc_id}/'
+        self.data = f'{data_path}{voc_id}/'
         self.quant = f'{self.data}quant/'
         self.mel = f'{self.data}mel/'
         self.gta = f'{self.data}gta/'


### PR DESCRIPTION
Hi, thanks for the great work! I've added the ability to control device placements on both tacotron and WaveRNN. By default, everything will use the gpu, but if the computer doesn't have CUDA support or if the user specifies to force CPU only via a flag, then it will use the CPU instead. I have tested this out on both CPU and GPU and have confirmed that it is working.

New Features:
* `models_tacotron.py`, `deepmind_version.py`, and `fatchord_version.py`, and other helper functions all have tensors placed on same device as model parameters, enabling `model.to(device)` to correctly determine device to use.
* `quick_start.py`, `train_wavenet.py`, and `train_tacotron.py` all intelligently select whether to use GPU or CPU

Fixes:
* Relative import issue when importing a model on python 3 fixed

Minor Changes:
* `.gitignore` now excludes common python files.
* renamed `init_hidden()` in `init_`deepmind_version.py` to `get_initial_hidden()` to avoid implying that the function does any internal initialization of state rather than getting a default hidden state vector.
* Most of code refactored to avoid spaces before colons in function definitions, if elif else guards, and with statements.
* Executable scripts now print out which device they are using at the start of their scripts for explicitness and ease of debugging.
