### PR TITLE
Enabled multi-gpu training, buffers, grad clip in vocoder, saving optimizer state, and more fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# PyCharm files
+# IDE files
 .idea
+.vscode
 
 # Mac files
 .DS_Store

--- a/gen_tacotron.py
+++ b/gen_tacotron.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
 
     simple_table([('WaveRNN', str(voc_k) + 'k'),
                   ('Tacotron', str(tts_k) + 'k'),
-                  ('r', tts_model.r.item()),
+                  ('r', tts_model.r),
                   ('Generation Mode', 'Batched' if batched else 'Unbatched'),
                   ('Target Samples', target if batched else 'N/A'),
                   ('Overlap Samples', overlap if batched else 'N/A')])

--- a/gen_wavernn.py
+++ b/gen_wavernn.py
@@ -7,7 +7,7 @@ import torch
 import argparse
 
 
-def gen_testset(model, test_set, samples, batched, target, overlap, save_path):
+def gen_testset(model: WaveRNN, test_set, samples, batched, target, overlap, save_path):
 
     k = model.get_step() // 1000
 
@@ -34,7 +34,7 @@ def gen_testset(model, test_set, samples, batched, target, overlap, save_path):
         _ = model.generate(m, save_str, batched, target, overlap, hp.mu_law)
 
 
-def gen_from_file(model, load_path, save_path, batched, target, overlap):
+def gen_from_file(model: WaveRNN, load_path, save_path, batched, target, overlap):
 
     k = model.get_step() // 1000
     file_name = load_path.split('/')[-1]

--- a/gen_wavernn.py
+++ b/gen_wavernn.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     parser.add_argument('--overlap', '-o', type=int, help='[int] number of crossover samples')
     parser.add_argument('--file', '-f', type=str, help='[string/path] for testing a wav outside dataset')
     parser.add_argument('--weights', '-w', type=str, help='[string/path] checkpoint file to load weights from')
-    parser.add_argument('--gta', '-g', dest='use_gta', action='store_true', help='Generate from GTA testset')
+    parser.add_argument('--gta', '-g', dest='gta', action='store_true', help='Generate from GTA testset')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
 
     parser.set_defaults(batched=hp.voc_gen_batched)

--- a/hparams.py
+++ b/hparams.py
@@ -52,6 +52,7 @@ voc_total_steps = 1_000_000         # Total number of training steps
 voc_test_samples = 50               # How many unseen samples to put aside for testing
 voc_pad = 2                         # this will pad the input so that the resnet can 'see' wider than input length
 voc_seq_len = hop_length * 5        # must be a multiple of hop_length
+voc_clip_grad_norm = 4              # set to None if no gradient clipping needed
 
 # Generating / Synthesizing
 voc_gen_batched = True              # very fast (realtime+) single utterance batched generation

--- a/models/deepmind_version.py
+++ b/models/deepmind_version.py
@@ -167,7 +167,9 @@ class WaveRNN(nn.Module):
         device = next(self.parameters()).device  # use same device as parameters
         return torch.zeros(batch_size, self.hidden_size, device=device)
     
-    def num_params(self):
+    def num_params(self, print_out=True):
         parameters = filter(lambda p: p.requires_grad, self.parameters())
         parameters = sum([np.prod(p.size()) for p in parameters]) / 1_000_000
-        print('Trainable Parameters: %.3f million' % parameters)
+        if print_out:
+            print('Trainable Parameters: %.3f million' % parameters)
+        return parameters

--- a/models/deepmind_version.py
+++ b/models/deepmind_version.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from utils.display import *
 from utils.dsp import *
+import numpy as np
 
 class WaveRNN(nn.Module):
     def __init__(self, hidden_size=896, quantisation=256):

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -416,3 +416,4 @@ class WaveRNN(nn.Module):
         parameters = sum([np.prod(p.size()) for p in parameters]) / 1_000_000
         if print_out:
             print('Trainable Parameters: %.3fM' % parameters)
+        return parameters

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -113,7 +113,7 @@ class WaveRNN(nn.Module):
         self.fc2 = nn.Linear(fc_dims + self.aux_dims, fc_dims)
         self.fc3 = nn.Linear(fc_dims, self.n_classes)
 
-        self.step = nn.Parameter(torch.zeros(1).long(), requires_grad=False)
+        self.register_buffer('step', torch.zeros(1, dtype=torch.long))
         self.num_params()
 
     def forward(self, x, mels):

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -407,9 +407,9 @@ class WaveRNN(nn.Module):
             print(f'\nLoading Weights: "{path}"\n')
             self.load(path)
 
-    def load(self, path, device='cpu'):
-        # because PyTorch places on CPU by default, we follow those semantics by
-        # using CPU as default.
+    def load(self, path):
+        # Use device of model params as location for loaded state
+        device = next(self.parameters()).device
         self.load_state_dict(torch.load(path, map_location=device), strict=False)
 
     def save(self, path):

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -388,9 +388,12 @@ class WaveRNN(nn.Module):
     def get_step(self):
         return self.step.data.item()
 
-    def checkpoint(self, path):
+    def checkpoint(self, path, optimizer):
+        # Optimizer can be given as an argument because checkpoint function is
+        # only useful in context of already existing training process.
         k_steps = self.get_step() // 1000
         self.save(f'{path}/checkpoint_{k_steps}k_steps.pyt')
+        torch.save(optimizer.get_state(), f'{path}/checkpoint_{k_steps}k_steps_optim.pyt')
 
     def log(self, path, msg):
         with open(path, 'a') as f:
@@ -405,10 +408,14 @@ class WaveRNN(nn.Module):
             self.load(path)
 
     def load(self, path, device='cpu'):
-        # because PyTorch places on CPU by default, we follow those semantics by using CPU as default.
+        # because PyTorch places on CPU by default, we follow those semantics by
+        # using CPU as default.
         self.load_state_dict(torch.load(path, map_location=device), strict=False)
 
     def save(self, path):
+        # No optimizer argument because saving a model should not include data
+        # only relevant in the training process - it should only be properties
+        # of the model itself. Let caller take care of saving optimzier state.
         torch.save(self.state_dict(), path)
 
     def num_params(self, print_out=True):

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -240,13 +240,13 @@ class WaveRNN(nn.Module):
         output = output.cpu().numpy()
         output = output.astype(np.float64)
 
+        if mu_law:
+            output = decode_mu_law(output, self.n_classes, False)
+
         if batched:
             output = self.xfade_and_unfold(output, target, overlap)
         else:
             output = output[0]
-
-        if mu_law:
-            output = decode_mu_law(output, self.n_classes, False)
 
         # Fade-out at the end to avoid signal cutting out suddenly
         fade_out = np.linspace(1, 0, 20 * self.hop_length)

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -5,6 +5,7 @@ from utils.distribution import sample_from_discretized_mix_logistic
 from utils.display import *
 from utils.dsp import *
 import os
+import numpy as np
 
 
 class ResBlock(nn.Module):

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -279,10 +279,8 @@ class Tacotron(nn.Module):
         self.init_model()
         self.num_params()
 
-        # Unfortunately I have to put these settings into params in order to save
-        # if anyone knows a better way of doing this please open an issue in the repo
-        self.step = nn.Parameter(torch.zeros(1).long(), requires_grad=False)
-        self.r = nn.Parameter(torch.tensor(0).long(), requires_grad=False)
+        self.register_buffer('step', torch.zeros(1, dtype=torch.long))
+        self.register_buffer('r', torch.tensor(0, dtype=torch.long))
 
     def set_r(self, r):
         self.r.data = torch.tensor(r)
@@ -430,7 +428,9 @@ class Tacotron(nn.Module):
         return self.step.data.item()
 
     def reset_step(self):
-        self.step = nn.Parameter(torch.zeros(1).long(), requires_grad=False)
+        assert self.step is not None
+        # assignment to parameters or buffers is overloaded, updates internal dict entry
+        self.step = torch.zeros(1, dtype=torch.long)
 
     def checkpoint(self, path):
         k_steps = self.get_step() // 1000

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -432,9 +432,12 @@ class Tacotron(nn.Module):
         # assignment to parameters or buffers is overloaded, updates internal dict entry
         self.step = torch.zeros(1, dtype=torch.long)
 
-    def checkpoint(self, path):
+    def checkpoint(self, path, optimizer):
+        # Optimizer can be given as an argument because checkpoint function is
+        # only useful in context of already existing training process.
         k_steps = self.get_step() // 1000
         self.save(f'{path}/checkpoint_{k_steps}k_steps.pyt')
+        torch.save(optimizer.get_state(), f'{path}/checkpoint_{k_steps}k_steps_optim.pyt')
 
     def log(self, path, msg):
         with open(path, 'a') as f:
@@ -454,6 +457,9 @@ class Tacotron(nn.Module):
         self.load_state_dict(torch.load(path, map_location=device), strict=False)
 
     def save(self, path):
+        # No optimizer argument because saving a model should not include data
+        # only relevant in the training process - it should only be properties
+        # of the model itself. Let caller take care of saving optimzier state.
         torch.save(self.state_dict(), path)
 
     def num_params(self, print_out=True):

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -204,10 +204,12 @@ class LSA(nn.Module):
 
 
 class Decoder(nn.Module):
+    # Class variable because its value doesn't change between classes
+    # yet ought to be scoped by class because its a property of a Decoder
+    max_r = 20
     def __init__(self, n_mels, decoder_dims, lstm_dims):
         super().__init__()
-        self.max_r = 20
-        self.r = None
+        self.register_buffer('r', torch.tensor(0, dtype=torch.int))
         self.generating = False
         self.n_mels = n_mels
         self.prenet = PreNet(n_mels)
@@ -294,14 +296,14 @@ class Tacotron(nn.Module):
         self.num_params()
 
         self.register_buffer('step', torch.zeros(1, dtype=torch.long))
-        self.register_buffer('r', torch.tensor(0, dtype=torch.long))
+    
+    @property
+    def r(self):
+        return self.decoder.r.item()
 
-    def set_r(self, r):
-        self.r.data = torch.tensor(r)
-        self.decoder.r = r
-
-    def get_r(self):
-        return self.r.item()
+    @r.setter
+    def r(self, value):
+        self.decoder.r = self.decoder.r.new_tensor(value, requires_grad=False)
 
     def forward(self, x, m, generate_gta=False):
         device = next(self.parameters()).device  # use same device as parameters
@@ -363,7 +365,7 @@ class Tacotron(nn.Module):
         
         # For easy visualisation
         attn_scores = torch.cat(attn_scores, 1)
-        attn_scores = attn_scores.cpu().data.numpy()
+        # attn_scores = attn_scores.cpu().data.numpy()
             
         return mel_outputs, linear, attn_scores
     
@@ -443,8 +445,9 @@ class Tacotron(nn.Module):
 
     def reset_step(self):
         assert self.step is not None
+        device = next(self.parameters()).device  # use same device as parameters
         # assignment to parameters or buffers is overloaded, updates internal dict entry
-        self.step = torch.zeros(1, dtype=torch.long)
+        self.step = torch.zeros(1, dtype=torch.long, device=device)
 
     def checkpoint(self, path, optimizer):
         # Optimizer can be given as an argument because checkpoint function is
@@ -464,7 +467,6 @@ class Tacotron(nn.Module):
         else:
             print(f'\nLoading Weights: "{path}"\n')
             self.load(path)
-            self.decoder.r = self.r.item()
 
     def load(self, path):
         # Use device of model params as location for loaded state

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -452,8 +452,9 @@ class Tacotron(nn.Module):
             self.load(path)
             self.decoder.r = self.r.item()
 
-    def load(self, path, device='cpu'):
-        # because PyTorch places on CPU by default, we follow those semantics by using CPU as default.
+    def load(self, path):
+        # Use device of model params as location for loaded state
+        device = next(self.parameters()).device
         self.load_state_dict(torch.load(path, map_location=device), strict=False)
 
     def save(self, path):

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -209,7 +209,7 @@ class Decoder(nn.Module):
     max_r = 20
     def __init__(self, n_mels, decoder_dims, lstm_dims):
         super().__init__()
-        self.register_buffer('r', torch.tensor(0, dtype=torch.int))
+        self.register_buffer('r', torch.tensor(1, dtype=torch.int))
         self.generating = False
         self.n_mels = n_mels
         self.prenet = PreNet(n_mels)

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -461,3 +461,4 @@ class Tacotron(nn.Module):
         parameters = sum([np.prod(p.size()) for p in parameters]) / 1_000_000
         if print_out:
             print('Trainable Parameters: %.3fM' % parameters)
+        return parameters

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -204,8 +204,7 @@ class Decoder(nn.Module):
         self.mel_proj = nn.Linear(lstm_dims, n_mels * self.max_r, bias=False)
         
     def zoneout(self, prev, current, p=0.1):
-        device = prev.device
-        assert prev.device == current.device
+        device = next(self.parameters()).device  # Use same device as parameters
         mask = torch.zeros(prev.size(), device=device).bernoulli_(p)
         return prev * mask + current * (1 - mask)
     

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -125,7 +125,7 @@ class CBHG(nn.Module):
         x, _ = self.rnn(x)
         return x
 
-    def _parameters(self):
+    def _flatten_parameters(self):
         """Calls `flatten_parameters` on all the rnns used by the WaveRNN. Used
         to improve efficiency and avoid PyTorch yelling at us."""
         [m.flatten_parameters() for m in self._to_flatten]

--- a/preprocess.py
+++ b/preprocess.py
@@ -60,13 +60,17 @@ else:
         with open(f'{paths.data}text_dict.pkl', 'wb') as f:
             pickle.dump(text_dict, f)
 
-    simple_table([('Sample Rate', hp.sample_rate),
-                  ('Bit Depth', hp.bits),
-                  ('Mu Law', hp.mu_law),
-                  ('Hop Length', hp.hop_length),
-                  ('CPU Count', cpu_count())])
+    n_processes = min(8, cpu_count())
 
-    pool = Pool(processes=cpu_count())
+    simple_table([
+        ('Sample Rate', hp.sample_rate),
+        ('Bit Depth', hp.bits),
+        ('Mu Law', hp.mu_law),
+        ('Hop Length', hp.hop_length),
+        ('CPU Usage', f'{n_processes}/{cpu_count()}')
+    ])
+
+    pool = Pool(processes=n_processes)
     dataset = []
 
     for i, (id, length) in enumerate(pool.imap_unordered(process_wav, wav_files), 1):

--- a/quick_start.py
+++ b/quick_start.py
@@ -119,6 +119,6 @@ if __name__ == "__main__":
         m = torch.tensor(m).unsqueeze(0)
         m = (m + 4) / 8
 
-        voc_model.generate(m, save_path, batched, hp.voc_target, hp.voc_overlap, hp.mu_law)
+        voc_model.generate(m, save_path, batched, target, overlap, hp.mu_law)
 
     print('\n\nDone.\n')

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -35,7 +35,7 @@ def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
             x, m = x.to(device), m.to(device)
 
             # Parallelize model onto GPUS using workaround due to python bug
-            if device == torch.device('cuda') and torch.cuda.device_count() > 1:
+            if device.type == 'cuda' and torch.cuda.device_count() > 1:
                 m1_hat, m2_hat, attention = data_parallel_workaround(model, x, m)
             else:
                 m1_hat, m2_hat, attention = model(x, m) 

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -168,14 +168,14 @@ if __name__ == "__main__":
 
                 train_set, attn_example = get_tts_dataset(paths.data, batch_size, r)
 
-                model.set_r(r)
+                model.r = r
 
                 training_steps = max_step - current_step
 
                 simple_table([(f'Steps with r={r}', str(training_steps//1000) + 'k Steps'),
                               ('Batch Size', batch_size),
                               ('Learning Rate', lr),
-                              ('Outputs/Step (r)', model.get_r())])
+                              ('Outputs/Step (r)', model.r)])
 
                 tts_train_loop(model, optimizer, train_set, lr, training_steps, attn_example)
 
@@ -185,7 +185,7 @@ if __name__ == "__main__":
 
     print('Creating Ground Truth Aligned Dataset...\n')
 
-    train_set, attn_example = get_tts_dataset(paths.data, 8, model.get_r())
+    train_set, attn_example = get_tts_dataset(paths.data, 8, model.r)
     create_gta_features(model, train_set, paths.gta)
 
     print('\n\nYou can now train WaveRNN on GTA features - use python train_wavernn.py --gta\n')

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
 
     optimizer = optim.Adam(model.parameters())
     if os.path.isfile(paths.tts_latest_optim):
-        print(f'Loading Optimizer State: "{paths.tts_latest_optim}"')
+        print(f'Loading Optimizer State: "{paths.tts_latest_optim}"\n')
         optimizer.load_state_dict(torch.load(paths.tts_latest_optim))
 
     current_step = model.get_step()

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -15,7 +15,7 @@ import os
 def np_now(x): return x.detach().cpu().numpy()
 
 
-def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
+def tts_train_loop(model: Tacotron, optimizer, train_set, lr, train_steps, attn_example):
     device = next(model.parameters()).device  # use same device as model parameters
 
     for p in optimizer.param_groups: p['lr'] = lr
@@ -81,7 +81,7 @@ def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
         print(' ')
 
 
-def create_gta_features(model, train_set, save_path):
+def create_gta_features(model: Tacotron, train_set, save_path):
     device = next(model.parameters()).device  # use same device as model parameters
 
     iters = len(train_set)

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -33,7 +33,7 @@ def voc_train_loop(model, loss_func, optimizer, train_set, test_set, lr, total_s
             x, m, y = x.to(device), m.to(device), y.to(device)
         
             # Parallelize model onto GPUS using workaround due to python bug
-            if device == torch.device('cuda') and torch.cuda.device_count() > 1:
+            if device.type == 'cuda' and torch.cuda.device_count() > 1:
                 y_hat = data_parallel_workaround(model, x, m)
             else:
                 y_hat = model(x, m)

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -15,7 +15,7 @@ from utils import data_parallel_workaround
 import os
 
 
-def voc_train_loop(model, loss_func, optimizer, train_set, test_set, lr, total_steps):
+def voc_train_loop(model: WaveRNN, loss_func, optimizer, train_set, test_set, lr, total_steps):
     # Use same device as model parameters
     device = next(model.parameters()).device
     
@@ -56,6 +56,7 @@ def voc_train_loop(model, loss_func, optimizer, train_set, test_set, lr, total_s
                 if np.isnan(grad_norm):
                     print('grad_norm was NaN!')
             optimizer.step()
+            
             running_loss += loss.item()
 
             speed = i / (time.time() - start)

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
     optimizer = optim.Adam(voc_model.parameters())
     if os.path.isfile(paths.voc_latest_optim):
-        print(f'Loading Optimizer State: "{paths.voc_latest_optim}"')
+        print(f'Loading Optimizer State: "{paths.voc_latest_optim}"\n')
         optimizer.load_state_dict(torch.load(paths.voc_latest_optim))
 
     train_set, test_set = get_vocoder_datasets(paths.data, batch_size, train_gta)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,31 @@
+# Make it explicit we do it the Python 3 way
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
+import sys
+import torch
+
+# Credit: Ryuichi Yamamoto (https://github.com/r9y9/wavenet_vocoder/blob/1717f145c8f8c0f3f85ccdf346b5209fa2e1c920/train.py#L599)
+# workaround for https://github.com/pytorch/pytorch/issues/15716
+# the idea is to return outputs and replicas explicitly, so that making pytorch
+# not to release the nodes (this is a pytorch bug though)
+
+_output_ref = None
+_replicas_ref = None
+
+def data_parallel_workaround(model, *input):
+    global _output_ref
+    global _replicas_ref
+    device_ids = list(range(torch.cuda.device_count()))
+    output_device = device_ids[0]
+    replicas = torch.nn.parallel.replicate(model, device_ids)
+    # input.shape = (num_args, batch, ...)
+    inputs = torch.nn.parallel.scatter(input, device_ids)
+    # inputs.shape = (num_gpus, num_args, batch/num_gpus, ...)
+    replicas = replicas[:len(inputs)]
+    outputs = torch.nn.parallel.parallel_apply(replicas, inputs)
+    y_hat = torch.nn.parallel.gather(outputs, output_device)
+    _output_ref = outputs
+    _replicas_ref = replicas
+    return y_hat
+

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -11,12 +11,14 @@ class Paths:
         # WaveRNN/Vocoder Paths
         self.voc_checkpoints = f'checkpoints/{voc_id}.wavernn/'
         self.voc_latest_weights = f'{self.voc_checkpoints}latest_weights.pyt'
+        self.voc_latest_optim = f'{self.voc_checkpoints}latest_optim.pyt'
         self.voc_output = f'model_outputs/{voc_id}.wavernn/'
         self.voc_step = f'{self.voc_checkpoints}/step.npy'
         self.voc_log = f'{self.voc_checkpoints}log.txt'
         # Tactron/TTS Paths
         self.tts_checkpoints = f'checkpoints/{tts_id}.tacotron/'
         self.tts_latest_weights = f'{self.tts_checkpoints}latest_weights.pyt'
+        self.tts_latest_optim = f'{self.tts_checkpoints}latest_optim.pyt'
         self.tts_output = f'model_outputs/{tts_id}.tts/'
         self.tts_step = f'{self.tts_checkpoints}/step.npy'
         self.tts_log = f'{self.tts_checkpoints}log.txt'


### PR DESCRIPTION
+ Added `voc_clip_grad_norm` hparam
+ Enabled gradient clipping in vocoder
+ Added warning when gradient is nan in vocoder and synthesizer
+ Added workaround for broken nn.DataParallel in `utils.__init__.py`
* Refactored `tacotron.py` and `fatchord_version.py` to store step
  in a PyTorch buffer instead of a gradient-less parameter
* Refactored training code for WaveRNN and tacotron to automagically
  use data parallelism when in the presence of multiple GPUS.
! Note that your batch size must be divisible by the number of GPUS