### PR TITLE
Add Multi-GPU training, Griffin-Lim vocoder, safely restore checkpoints, pathlib, multiple hparams files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# PyCharm files
+# IDE files
 .idea
+.vscode
 
 # Mac files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pytorch implementation of Deepmind's WaveRNN model from [Efficient Neural Audio 
 
 # Installation
 
-Ensure you have: 
+Ensure you have:
 
 * Python >= 3.6
 * [Pytorch 1 with CUDA](https://pytorch.org/)
@@ -37,20 +37,20 @@ You can also use that script to generate custom tts sentences and/or use '-u' to
 
 Download the [LJSpeech](https://keithito.com/LJ-Speech-Dataset/) Dataset.
 
-Edit **hparams.py**, point **wav_path** to your dataset and run: 
+Edit **hparams.py**, point **wav_path** to your dataset and run:
 
 > python preprocess.py
 
 or use preprocess.py --path to point directly to the dataset
 ___
 
-Here's my recommendation on what order to run things: 
+Here's my recommendation on what order to run things:
 
 1 - Train Tacotron with:
 
 > python train_tacotron.py
 
-2 - You can leave that finish training or at any point you can use: 
+2 - You can leave that finish training or at any point you can use:
 
 > python train_tacotron.py --force_gta
 
@@ -64,11 +64,11 @@ NB: You can always just run train_wavernn.py without --gta if you're not interes
 
 4 - Generate Sentences with both models using:
 
-> python gen_tacotron.py
+> python gen_tacotron.py wavernn
 
 this will generate default sentences. If you want generate custom sentences you can use
 
-> python gen_tacotron.py --input_text "this is whatever you want it to be"
+> python gen_tacotron.py --input_text "this is whatever you want it to be" wavernn
 
 And finally, you can always use --help on any of those scripts to see what options are available :)
 
@@ -84,7 +84,7 @@ Currently there are two pretrained models available in the /pretrained/ folder':
 
 Both are trained on LJSpeech
 
-* WaveRNN (Mixture of Logistics output) trained to 800k steps 
+* WaveRNN (Mixture of Logistics output) trained to 800k steps
 * Tacotron trained to 180k steps
 
 ____
@@ -100,7 +100,3 @@ ____
 * [https://github.com/keithito/tacotron](https://github.com/keithito/tacotron)
 * [https://github.com/r9y9/wavenet_vocoder](https://github.com/r9y9/wavenet_vocoder)
 * Special thanks to github users [G-Wang](https://github.com/G-Wang), [geneing](https://github.com/geneing) & [erogol](https://github.com/erogol)
-
-
-
-

--- a/gen_tacotron.py
+++ b/gen_tacotron.py
@@ -112,9 +112,9 @@ if __name__ == "__main__":
         _, m, attention = tts_model.generate(x)
 
         if input_text:
-            save_path = f'{paths.tts_output}__input_{input_text[:10]}_{tts_k}k.wav'
+            save_path = paths.tts_output/f'__input_{input_text[:10]}_{tts_k}k.wav'
         else:
-            save_path = f'{paths.tts_output}{i}_batched{str(batched)}_{tts_k}k.wav'
+            save_path = paths.tts_output/f'{i}_batched{str(batched)}_{tts_k}k.wav'
 
         if save_attn: save_attention(attention, save_path)
 

--- a/gen_tacotron.py
+++ b/gen_tacotron.py
@@ -102,7 +102,8 @@ if __name__ == "__main__":
                          lstm_dims=hp.tts_lstm_dims,
                          postnet_K=hp.tts_postnet_K,
                          num_highways=hp.tts_num_highways,
-                         dropout=hp.tts_dropout).to(device)
+                         dropout=hp.tts_dropout,
+                         stop_threshold=hp.tts_stop_threshold).to(device)
 
     tts_restore_path = weights_path if weights_path else paths.tts_latest_weights
     tts_model.load(tts_restore_path)

--- a/gen_tacotron.py
+++ b/gen_tacotron.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
 
     simple_table([('WaveRNN', str(voc_k) + 'k'),
                   ('Tacotron', str(tts_k) + 'k'),
-                  ('r', tts_model.r.item()),
+                  ('r', tts_model.r),
                   ('Generation Mode', 'Batched' if batched else 'Unbatched'),
                   ('Target Samples', target if batched else 'N/A'),
                   ('Overlap Samples', overlap if batched else 'N/A')])

--- a/gen_tacotron.py
+++ b/gen_tacotron.py
@@ -1,6 +1,6 @@
 import torch
 from models.fatchord_version import WaveRNN
-import hparams as hp
+from utils import hparams as hp
 from utils.text.symbols import symbols
 from utils.paths import Paths
 from models.tacotron import Tacotron

--- a/gen_tacotron.py
+++ b/gen_tacotron.py
@@ -7,40 +7,58 @@ from models.tacotron import Tacotron
 import argparse
 from utils.text import text_to_sequence
 from utils.display import save_attention, simple_table
+from utils.dsp import reconstruct_waveform, save_wav
 
 if __name__ == "__main__":
 
     # Parse Arguments
     parser = argparse.ArgumentParser(description='TTS Generator')
     parser.add_argument('--input_text', '-i', type=str, help='[string] Type in something here and TTS will generate it!')
-    parser.add_argument('--batched', '-b', dest='batched', action='store_true', help='Fast Batched Generation')
-    parser.add_argument('--unbatched', '-u', dest='batched', action='store_false', help='Slow Unbatched Generation')
-    parser.add_argument('--target', '-t', type=int, help='[int] number of samples in each batch index')
-    parser.add_argument('--overlap', '-o', type=int, help='[int] number of crossover samples')
     parser.add_argument('--weights_path', '-w', type=str, help='[string/path] Load in different Tacotron Weights')
     parser.add_argument('--save_attention', '-a', dest='save_attn', action='store_true', help='Save Attention Plots')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
     parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
 
-    parser.set_defaults(batched=None)
     parser.set_defaults(input_text=None)
     parser.set_defaults(weights_path=None)
     parser.set_defaults(save_attention=False)
 
+    # name of subcommand goes to args.vocoder
+    subparsers = parser.add_subparsers(required=True, dest='vocoder')
+
+    wr_parser = subparsers.add_parser('wavernn', aliases=['wr'])
+    wr_parser.add_argument('--batched', '-b', dest='batched', action='store_true', help='Fast Batched Generation')
+    wr_parser.add_argument('--unbatched', '-u', dest='batched', action='store_false', help='Slow Unbatched Generation')
+    wr_parser.add_argument('--overlap', '-o', type=int, help='[int] number of crossover samples')
+    wr_parser.add_argument('--target', '-t', type=int, help='[int] number of samples in each batch index')
+    wr_parser.set_defaults(batched=None)
+
+    gl_parser = subparsers.add_parser('griffinlim', aliases=['gl'])
+    gl_parser.add_argument('--iters', type=int, default=32, help='[int] number of griffinlim iterations')
+
     args = parser.parse_args()
+
+    if args.vocoder in ['griffinlim', 'gl']:
+        args.vocoder = 'griffinlim'
+    elif args.vocoder in ['wavernn', 'wr']:
+        args.vocoder = 'wavernn'
+    else:
+        raise argparse.ArgumentError('Must provide a valid vocoder type!')
 
     hp.configure(args.hp_file)  # Load hparams from file
     # set defaults for any arguments that depend on hparams
-    if args.target is None:
-        args.target = hp.voc_target
-    if args.overlap is None:
-        args.overlap = hp.voc_overlap
-    if args.batched is None:
-        args.batched = hp.voc_gen_batched
+    if args.vocoder == 'wavernn':
+        if args.target is None:
+            args.target = hp.voc_target
+        if args.overlap is None:
+            args.overlap = hp.voc_overlap
+        if args.batched is None:
+            args.batched = hp.voc_gen_batched
 
-    batched = args.batched
-    target = args.target
-    overlap = args.overlap
+        batched = args.batched
+        target = args.target
+        overlap = args.overlap
+
     input_text = args.input_text
     weights_path = args.weights_path
     save_attn = args.save_attention
@@ -53,23 +71,22 @@ if __name__ == "__main__":
         device = torch.device('cpu')
     print('Using device:', device)
 
-    print('\nInitialising WaveRNN Model...\n')
-
-    # Instantiate WaveRNN Model
-    voc_model = WaveRNN(rnn_dims=hp.voc_rnn_dims,
-                        fc_dims=hp.voc_fc_dims,
-                        bits=hp.bits,
-                        pad=hp.voc_pad,
-                        upsample_factors=hp.voc_upsample_factors,
-                        feat_dims=hp.num_mels,
-                        compute_dims=hp.voc_compute_dims,
-                        res_out_dims=hp.voc_res_out_dims,
-                        res_blocks=hp.voc_res_blocks,
-                        hop_length=hp.hop_length,
-                        sample_rate=hp.sample_rate,
-                        mode=hp.voc_mode).to(device)
-
-    voc_model.load(paths.voc_latest_weights)
+    if args.vocoder == 'wavernn':
+        print('\nInitialising WaveRNN Model...\n')
+        # Instantiate WaveRNN Model
+        voc_model = WaveRNN(rnn_dims=hp.voc_rnn_dims,
+                            fc_dims=hp.voc_fc_dims,
+                            bits=hp.bits,
+                            pad=hp.voc_pad,
+                            upsample_factors=hp.voc_upsample_factors,
+                            feat_dims=hp.num_mels,
+                            compute_dims=hp.voc_compute_dims,
+                            res_out_dims=hp.voc_res_out_dims,
+                            res_blocks=hp.voc_res_blocks,
+                            hop_length=hp.hop_length,
+                            sample_rate=hp.sample_rate,
+                            mode=hp.voc_mode).to(device)
+        voc_model.load(paths.voc_latest_weights)
 
     print('\nInitialising Tacotron Model...\n')
 
@@ -96,31 +113,52 @@ if __name__ == "__main__":
         with open('sentences.txt') as f:
             inputs = [text_to_sequence(l.strip(), hp.tts_cleaner_names) for l in f]
 
-    voc_k = voc_model.get_step() // 1000
-    tts_k = tts_model.get_step() // 1000
+    if args.vocoder == 'wavernn':
+        voc_k = voc_model.get_step() // 1000
+        tts_k = tts_model.get_step() // 1000
 
-    simple_table([('WaveRNN', str(voc_k) + 'k'),
-                  ('Tacotron', str(tts_k) + 'k'),
-                  ('r', tts_model.r),
-                  ('Generation Mode', 'Batched' if batched else 'Unbatched'),
-                  ('Target Samples', target if batched else 'N/A'),
-                  ('Overlap Samples', overlap if batched else 'N/A')])
+        simple_table([('Tacotron', str(tts_k) + 'k'),
+                    ('r', tts_model.r),
+                    ('Vocoder Type', 'WaveRNN'),
+                    ('WaveRNN', str(voc_k) + 'k'),
+                    ('Generation Mode', 'Batched' if batched else 'Unbatched'),
+                    ('Target Samples', target if batched else 'N/A'),
+                    ('Overlap Samples', overlap if batched else 'N/A')])
+
+    elif args.vocoder == 'griffinlim':
+        tts_k = tts_model.get_step() // 1000
+        simple_table([('Tacotron', str(tts_k) + 'k'),
+                    ('r', tts_model.r),
+                    ('Vocoder Type', 'Griffin-Lim'),
+                    ('GL Iters', args.iters)])
 
     for i, x in enumerate(inputs, 1):
 
         print(f'\n| Generating {i}/{len(inputs)}')
         _, m, attention = tts_model.generate(x)
 
-        if input_text:
-            save_path = paths.tts_output/f'__input_{input_text[:10]}_{tts_k}k.wav'
+        if args.vocoder == 'griffinlim':
+            v_type = args.vocoder
+        elif args.vocoder == 'wavernn' and args.batched:
+            v_type = 'wavernn_batched'
         else:
-            save_path = paths.tts_output/f'{i}_batched{str(batched)}_{tts_k}k.wav'
+            v_type = 'wavernn_unbatched'
+
+        if input_text:
+            save_path = paths.tts_output/f'__input_{input_text[:10]}_{v_type}_{tts_k}k.wav'
+        else:
+            save_path = paths.tts_output/f'{i}_{v_type}_{tts_k}k.wav'
 
         if save_attn: save_attention(attention, save_path)
 
-        m = torch.tensor(m).unsqueeze(0)
-        m = (m + 4) / 8
+        if args.vocoder == 'wavernn':
+            m = torch.tensor(m).unsqueeze(0)
+            m = (m + 4) / 8
 
-        voc_model.generate(m, save_path, batched, hp.voc_target, hp.voc_overlap, hp.mu_law)
+            voc_model.generate(m, save_path, batched, hp.voc_target, hp.voc_overlap, hp.mu_law)
+        elif args.vocoder == 'griffinlim':
+            wav = reconstruct_waveform(m, n_iter=args.iters)
+            save_wav(wav, save_path)
+
 
     print('\n\nDone.\n')

--- a/gen_wavernn.py
+++ b/gen_wavernn.py
@@ -61,14 +61,11 @@ if __name__ == "__main__":
     parser.add_argument('--target', '-t', type=int, help='[int] number of samples in each batch index')
     parser.add_argument('--overlap', '-o', type=int, help='[int] number of crossover samples')
     parser.add_argument('--file', '-f', type=str, help='[string/path] for testing a wav outside dataset')
-    parser.add_argument('--weights', '-w', type=str, help='[string/path] checkpoint file to load weights from')
+    parser.add_argument('--voc_weights', '-w', type=str, help='[string/path] Load in different WaveRNN weights')
     parser.add_argument('--gta', '-g', dest='gta', action='store_true', help='Generate from GTA testset')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
     parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
 
-    parser.set_defaults(file=None)
-    parser.set_defaults(weights=None)
-    parser.set_defaults(gta=False)
     parser.set_defaults(batched=None)
 
     args = parser.parse_args()
@@ -114,9 +111,9 @@ if __name__ == "__main__":
 
     paths = Paths(hp.data_path, hp.voc_model_id, hp.tts_model_id)
 
-    restore_path = args.weights if args.weights else paths.voc_latest_weights
+    voc_weights = args.voc_weights if args.voc_weights else paths.voc_latest_weights
 
-    model.load(restore_path)
+    model.load(voc_weights)
 
     simple_table([('Generation Mode', 'Batched' if batched else 'Unbatched'),
                   ('Target Samples', target if batched else 'N/A'),

--- a/gen_wavernn.py
+++ b/gen_wavernn.py
@@ -7,7 +7,7 @@ import torch
 import argparse
 
 
-def gen_testset(model, test_set, samples, batched, target, overlap, save_path):
+def gen_testset(model: WaveRNN, test_set, samples, batched, target, overlap, save_path):
 
     k = model.get_step() // 1000
 
@@ -34,7 +34,7 @@ def gen_testset(model, test_set, samples, batched, target, overlap, save_path):
         _ = model.generate(m, save_str, batched, target, overlap, hp.mu_law)
 
 
-def gen_from_file(model, load_path, save_path, batched, target, overlap):
+def gen_from_file(model: WaveRNN, load_path, save_path, batched, target, overlap):
 
     k = model.get_step() // 1000
     file_name = load_path.split('/')[-1]

--- a/gen_wavernn.py
+++ b/gen_wavernn.py
@@ -5,9 +5,10 @@ from utils.paths import Paths
 from utils.display import simple_table
 import torch
 import argparse
+from pathlib import Path
 
 
-def gen_testset(model: WaveRNN, test_set, samples, batched, target, overlap, save_path):
+def gen_testset(model: WaveRNN, test_set, samples, batched, target, overlap, save_path: Path):
 
     k = model.get_step() // 1000
 
@@ -26,27 +27,27 @@ def gen_testset(model: WaveRNN, test_set, samples, batched, target, overlap, sav
         else:
             x = label_2_float(x, bits)
 
-        save_wav(x, f'{save_path}{k}k_steps_{i}_target.wav')
+        save_wav(x, save_path/f'{k}k_steps_{i}_target.wav')
 
         batch_str = f'gen_batched_target{target}_overlap{overlap}' if batched else 'gen_NOT_BATCHED'
-        save_str = f'{save_path}{k}k_steps_{i}_{batch_str}.wav'
+        save_str = str(save_path/f'{k}k_steps_{i}_{batch_str}.wav')
 
         _ = model.generate(m, save_str, batched, target, overlap, hp.mu_law)
 
 
-def gen_from_file(model: WaveRNN, load_path, save_path, batched, target, overlap):
+def gen_from_file(model: WaveRNN, load_path, save_path: Path, batched, target, overlap):
 
     k = model.get_step() // 1000
     file_name = load_path.split('/')[-1]
 
     wav = load_wav(load_path)
-    save_wav(wav, f'{save_path}__{file_name}__{k}k_steps_target.wav')
+    save_wav(wav, save_path/f'__{file_name}__{k}k_steps_target.wav')
 
     mel = melspectrogram(wav)
     mel = torch.tensor(mel).unsqueeze(0)
 
     batch_str = f'gen_batched_target{target}_overlap{overlap}' if batched else 'gen_NOT_BATCHED'
-    save_str = f'{save_path}__{file_name}__{k}k_steps_{batch_str}.wav'
+    save_str = save_path/f'__{file_name}__{k}k_steps_{batch_str}.wav'
 
     _ = model.generate(mel, save_str, batched, target, overlap, hp.mu_law)
 

--- a/gen_wavernn.py
+++ b/gen_wavernn.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     parser.add_argument('--overlap', '-o', type=int, help='[int] number of crossover samples')
     parser.add_argument('--file', '-f', type=str, help='[string/path] for testing a wav outside dataset')
     parser.add_argument('--weights', '-w', type=str, help='[string/path] checkpoint file to load weights from')
-    parser.add_argument('--gta', '-g', dest='use_gta', action='store_true', help='Generate from GTA testset')
+    parser.add_argument('--gta', '-g', dest='gta', action='store_true', help='Generate from GTA testset')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
 
     parser.set_defaults(batched=hp.voc_gen_batched)

--- a/gen_wavernn.py
+++ b/gen_wavernn.py
@@ -63,16 +63,25 @@ if __name__ == "__main__":
     parser.add_argument('--weights', '-w', type=str, help='[string/path] checkpoint file to load weights from')
     parser.add_argument('--gta', '-g', dest='gta', action='store_true', help='Generate from GTA testset')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
+    parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
 
-    parser.set_defaults(batched=hp.voc_gen_batched)
-    parser.set_defaults(samples=hp.voc_gen_at_checkpoint)
-    parser.set_defaults(target=hp.voc_target)
-    parser.set_defaults(overlap=hp.voc_overlap)
     parser.set_defaults(file=None)
     parser.set_defaults(weights=None)
     parser.set_defaults(gta=False)
+    parser.set_defaults(batched=None)
 
     args = parser.parse_args()
+
+    hp.configure(args.hp_file)  # Load hparams from file
+    # set defaults for any arguments that depend on hparams
+    if args.target is None:
+        args.target = hp.voc_target
+    if args.overlap is None:
+        args.overlap = hp.voc_overlap
+    if args.batched is None:
+        args.batched = hp.voc_gen_batched
+    if args.samples is None:
+        args.samples = hp.voc_gen_at_checkpoint
 
     batched = args.batched
     samples = args.samples
@@ -106,7 +115,7 @@ if __name__ == "__main__":
 
     restore_path = args.weights if args.weights else paths.voc_latest_weights
 
-    model.restore(restore_path)
+    model.load(restore_path)
 
     simple_table([('Generation Mode', 'Batched' if batched else 'Unbatched'),
                   ('Target Samples', target if batched else 'N/A'),

--- a/hparams.py
+++ b/hparams.py
@@ -84,7 +84,7 @@ tts_stop_threshold = -3.4           # Value below which audio generation ends.
 tts_schedule = [(7,  1e-3,  10_000,  32),   # progressive training schedule
                 (5,  1e-4, 100_000,  32),   # (r, lr, step, batch_size)
                 (2,  1e-4, 180_000,  16),
-                (1,  1e-4, 350_000,  8)]
+                (2,  1e-4, 350_000,  8)]
 
 tts_max_mel_len = 1250              # if you have a couple of extremely long spectrograms you might want to use this
 tts_bin_lengths = True              # bins the spectrogram lengths before sampling in data loader - speeds up training

--- a/hparams.py
+++ b/hparams.py
@@ -52,6 +52,7 @@ voc_total_steps = 1_000_000         # Total number of training steps
 voc_test_samples = 50               # How many unseen samples to put aside for testing
 voc_pad = 2                         # this will pad the input so that the resnet can 'see' wider than input length
 voc_seq_len = hop_length * 5        # must be a multiple of hop_length
+voc_clip_grad_norm = 4              # set to None if no gradient clipping needed
 
 # Generating / Synthesizing
 voc_gen_batched = True              # very fast (realtime+) single utterance batched generation

--- a/hparams.py
+++ b/hparams.py
@@ -64,7 +64,6 @@ voc_overlap = 550                   # number of samples for crossfading between 
 
 
 # Model Hparams
-tts_r = 1                           # model predicts r frames per output step
 tts_embed_dims = 256                # embedding dimension for the graphemes/phoneme inputs
 tts_encoder_dims = 128
 tts_decoder_dims = 256
@@ -75,9 +74,12 @@ tts_postnet_K = 8
 tts_num_highways = 4
 tts_dropout = 0.5
 tts_cleaner_names = ['english_cleaners']
+tts_stop_threshold = -3.4           # Value below which audio generation ends.
+                                    # For example, for a range of [-4, 4], this
+                                    # will terminate the sequence at the first
+                                    # frame that has all values < -3.4
 
 # Training
-
 
 tts_schedule = [(7,  1e-3,  10_000,  32),   # progressive training schedule
                 (5,  1e-4, 100_000,  32),   # (r, lr, step, batch_size)

--- a/models/deepmind_version.py
+++ b/models/deepmind_version.py
@@ -167,7 +167,9 @@ class WaveRNN(nn.Module):
         device = next(self.parameters()).device  # use same device as parameters
         return torch.zeros(batch_size, self.hidden_size, device=device)
     
-    def num_params(self):
+    def num_params(self, print_out=True):
         parameters = filter(lambda p: p.requires_grad, self.parameters())
         parameters = sum([np.prod(p.size()) for p in parameters]) / 1_000_000
-        print('Trainable Parameters: %.3f million' % parameters)
+        if print_out:
+            print('Trainable Parameters: %.3f million' % parameters)
+        return parameters

--- a/models/deepmind_version.py
+++ b/models/deepmind_version.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from utils.display import *
 from utils.dsp import *
+import numpy as np
 
 class WaveRNN(nn.Module):
     def __init__(self, hidden_size=896, quantisation=256):

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -240,13 +240,13 @@ class WaveRNN(nn.Module):
         output = output.cpu().numpy()
         output = output.astype(np.float64)
 
+        if mu_law:
+            output = decode_mu_law(output, self.n_classes, False)
+
         if batched:
             output = self.xfade_and_unfold(output, target, overlap)
         else:
             output = output[0]
-
-        if mu_law:
-            output = decode_mu_law(output, self.n_classes, False)
 
         # Fade-out at the end to avoid signal cutting out suddenly
         fade_out = np.linspace(1, 0, 20 * self.hop_length)

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -167,11 +167,12 @@ class WaveRNN(nn.Module):
         return self.fc3(x)
 
     def generate(self, mels, save_path: Union[str, Path], batched, target, overlap, mu_law):
+        self.eval()
+        
         device = next(self.parameters()).device  # use same device as parameters
 
         mu_law = mu_law if self.mode == 'RAW' else False
 
-        self.eval()
         output = []
         start = time.time()
         rnn1 = self.get_gru_cell(self.rnn1)

--- a/models/fatchord_version.py
+++ b/models/fatchord_version.py
@@ -5,6 +5,7 @@ from utils.distribution import sample_from_discretized_mix_logistic
 from utils.display import *
 from utils.dsp import *
 import os
+import numpy as np
 
 
 class ResBlock(nn.Module):

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -281,7 +281,7 @@ class Decoder(nn.Module):
 
 class Tacotron(nn.Module):
     def __init__(self, embed_dims, num_chars, encoder_dims, decoder_dims, n_mels, fft_bins, postnet_dims,
-                 encoder_K, lstm_dims, postnet_K, num_highways, dropout):
+                 encoder_K, lstm_dims, postnet_K, num_highways, dropout, stop_threshold):
         super().__init__()
         self.n_mels = n_mels
         self.lstm_dims = lstm_dims
@@ -297,6 +297,7 @@ class Tacotron(nn.Module):
         self.num_params()
 
         self.register_buffer('step', torch.zeros(1, dtype=torch.long))
+        self.register_buffer('stop_threshold', torch.tensor(stop_threshold, dtype=torch.float32))
 
     @property
     def r(self):
@@ -407,7 +408,7 @@ class Tacotron(nn.Module):
             mel_outputs.append(mel_frames)
             attn_scores.append(scores)
             # Stop the loop if silent frames present
-            if (mel_frames < -3.8).all() and t > 10: break
+            if (mel_frames < self.stop_threshold).all() and t > 10: break
 
         # Concat the mel outputs into sequence
         mel_outputs = torch.cat(mel_outputs, dim=2)

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -13,7 +13,7 @@ class HighwayNetwork(nn.Module):
         self.W1 = nn.Linear(size, size)
         self.W2 = nn.Linear(size, size)
         self.W1.bias.data.fill_(0.)
-        
+
     def forward(self, x):
         x1 = self.W1(x)
         x2 = self.W2(x)
@@ -22,15 +22,15 @@ class HighwayNetwork(nn.Module):
         return y
 
 
-class Encoder(nn.Module): 
+class Encoder(nn.Module):
     def __init__(self, embed_dims, num_chars, cbhg_channels, K, num_highways, dropout):
         super().__init__()
         self.embedding = nn.Embedding(num_chars, embed_dims)
         self.pre_net = PreNet(embed_dims)
-        self.cbhg = CBHG(K=K, in_channels=cbhg_channels, channels=cbhg_channels, 
-                         proj_channels=[cbhg_channels, cbhg_channels], 
+        self.cbhg = CBHG(K=K, in_channels=cbhg_channels, channels=cbhg_channels,
+                         proj_channels=[cbhg_channels, cbhg_channels],
                          num_highways=num_highways)
-        
+
     def forward(self, x):
         x = self.embedding(x)
         x = self.pre_net(x)
@@ -45,20 +45,20 @@ class BatchNormConv(nn.Module):
         self.conv = nn.Conv1d(in_channels, out_channels, kernel, stride=1, padding=kernel // 2, bias=False)
         self.bnorm = nn.BatchNorm1d(out_channels)
         self.relu = relu
-        
+
     def forward(self, x):
         x = self.conv(x)
         x = F.relu(x) if self.relu is True else x
         return self.bnorm(x)
-    
-    
+
+
 class CBHG(nn.Module):
     def __init__(self, K, in_channels, channels, proj_channels, num_highways):
         super().__init__()
-        
+
         # List of all rnns to call `flatten_parameters()` on
         self._to_flatten = []
-        
+
         self.bank_kernels = [i for i in range(1, K + 1)]
         self.conv1d_bank = nn.ModuleList()
         for k in self.bank_kernels:
@@ -66,30 +66,30 @@ class CBHG(nn.Module):
             self.conv1d_bank.append(conv)
 
         self.maxpool = nn.MaxPool1d(kernel_size=2, stride=1, padding=1)
-                
+
         self.conv_project1 = BatchNormConv(len(self.bank_kernels) * channels, proj_channels[0], 3)
         self.conv_project2 = BatchNormConv(proj_channels[0], proj_channels[1], 3, relu=False)
-        
+
         # Fix the highway input if necessary
         if proj_channels[-1] != channels:
             self.highway_mismatch = True
             self.pre_highway = nn.Linear(proj_channels[-1], channels, bias=False)
         else:
             self.highway_mismatch = False
-        
+
         self.highways = nn.ModuleList()
         for i in range(num_highways):
             hn = HighwayNetwork(channels)
             self.highways.append(hn)
-        
+
         self.rnn = nn.GRU(channels, channels, batch_first=True, bidirectional=True)
         self._to_flatten.append(self.rnn)
 
         # Avoid fragmentation of RNN parameters and associated warning
         self._flatten_parameters()
-    
+
     def forward(self, x):
-        # Although we `_flatten_parameters()` on init, when using DataParallel 
+        # Although we `_flatten_parameters()` on init, when using DataParallel
         # the model gets replicated, making it no longer guaranteed that the
         # weights are contiguous in GPU memory. Hence, we must call it again
         self._flatten_parameters()
@@ -98,25 +98,25 @@ class CBHG(nn.Module):
         residual = x
         seq_len = x.size(-1)
         conv_bank = []
-        
+
         # Convolution Bank
         for conv in self.conv1d_bank:
             c = conv(x) # Convolution
             conv_bank.append(c[:, :, :seq_len])
-        
+
         # Stack along the channel axis
         conv_bank = torch.cat(conv_bank, dim=1)
-        
+
         # dump the last padding to fit residual
-        x = self.maxpool(conv_bank)[:, :, :seq_len] 
-        
+        x = self.maxpool(conv_bank)[:, :, :seq_len]
+
         # Conv1d projections
         x = self.conv_project1(x)
         x = self.conv_project2(x)
-        
+
         # Residual Connect
         x = x + residual
-        
+
         # Through the highways
         x = x.transpose(1, 2)
         if self.highway_mismatch is True:
@@ -138,7 +138,7 @@ class PreNet(nn.Module):
         self.fc1 = nn.Linear(in_dims, fc1_dims)
         self.fc2 = nn.Linear(fc1_dims, fc2_dims)
         self.p = dropout
-        
+
     def forward(self, x):
         x = self.fc1(x)
         x = F.relu(x)
@@ -147,21 +147,21 @@ class PreNet(nn.Module):
         x = F.relu(x)
         x = F.dropout(x, self.p, training=self.training)
         return x
-    
-    
+
+
 class Attention(nn.Module):
     def __init__(self, attn_dims):
         super().__init__()
         self.W = nn.Linear(attn_dims, attn_dims, bias=False)
         self.v = nn.Linear(attn_dims, 1, bias=False)
-        
+
     def forward(self, encoder_seq_proj, query, t):
 
         # print(encoder_seq_proj.shape)
         # Transform the query vector
         query_proj = self.W(query).unsqueeze(1)
-        
-        # Compute the scores 
+
+        # Compute the scores
         u = self.v(torch.tanh(encoder_seq_proj + query_proj))
         scores = F.softmax(u, dim=1)
 
@@ -220,40 +220,40 @@ class Decoder(nn.Module):
         self.res_rnn1 = nn.LSTMCell(lstm_dims, lstm_dims)
         self.res_rnn2 = nn.LSTMCell(lstm_dims, lstm_dims)
         self.mel_proj = nn.Linear(lstm_dims, n_mels * self.max_r, bias=False)
-        
+
     def zoneout(self, prev, current, p=0.1):
         device = next(self.parameters()).device  # Use same device as parameters
         mask = torch.zeros(prev.size(), device=device).bernoulli_(p)
         return prev * mask + current * (1 - mask)
-    
-    def forward(self, encoder_seq, encoder_seq_proj, prenet_in, 
+
+    def forward(self, encoder_seq, encoder_seq_proj, prenet_in,
                 hidden_states, cell_states, context_vec, t):
-        
+
         # Need this for reshaping mels
         batch_size = encoder_seq.size(0)
-        
+
         # Unpack the hidden and cell states
         attn_hidden, rnn1_hidden, rnn2_hidden = hidden_states
         rnn1_cell, rnn2_cell = cell_states
-        
+
         # PreNet for the Attention RNN
         prenet_out = self.prenet(prenet_in)
-        
+
         # Compute the Attention RNN hidden state
-        attn_rnn_in = torch.cat([context_vec, prenet_out], dim=-1)  
+        attn_rnn_in = torch.cat([context_vec, prenet_out], dim=-1)
         attn_hidden = self.attn_rnn(attn_rnn_in.squeeze(1), attn_hidden)
-        
-        # Compute the attention scores 
+
+        # Compute the attention scores
         scores = self.attn_net(encoder_seq_proj, attn_hidden, t)
-        
-        # Dot product to create the context vector 
+
+        # Dot product to create the context vector
         context_vec = scores @ encoder_seq
         context_vec = context_vec.squeeze(1)
 
         # Concat Attention RNN output w. Context Vector & project
         x = torch.cat([context_vec, attn_hidden], dim=1)
         x = self.rnn_input(x)
-        
+
         # Compute first Residual RNN
         rnn1_hidden_next, rnn1_cell = self.res_rnn1(x, (rnn1_hidden, rnn1_cell))
         if self.training:
@@ -261,7 +261,7 @@ class Decoder(nn.Module):
         else:
             rnn1_hidden = rnn1_hidden_next
         x = x + rnn1_hidden
-        
+
         # Compute second Residual RNN
         rnn2_hidden_next, rnn2_cell = self.res_rnn2(x, (rnn2_hidden, rnn2_cell))
         if self.training:
@@ -269,16 +269,16 @@ class Decoder(nn.Module):
         else:
             rnn2_hidden = rnn2_hidden_next
         x = x + rnn2_hidden
-        
+
         # Project Mels
         mels = self.mel_proj(x)
         mels = mels.view(batch_size, self.n_mels, self.max_r)[:, :, :self.r]
         hidden_states = (attn_hidden, rnn1_hidden, rnn2_hidden)
         cell_states = (rnn1_cell, rnn2_cell)
-        
+
         return mels, scores, hidden_states, cell_states, context_vec
-    
-    
+
+
 class Tacotron(nn.Module):
     def __init__(self, embed_dims, num_chars, encoder_dims, decoder_dims, n_mels, fft_bins, postnet_dims,
                  encoder_K, lstm_dims, postnet_K, num_highways, dropout):
@@ -286,7 +286,7 @@ class Tacotron(nn.Module):
         self.n_mels = n_mels
         self.lstm_dims = lstm_dims
         self.decoder_dims = decoder_dims
-        self.encoder = Encoder(embed_dims, num_chars, encoder_dims, 
+        self.encoder = Encoder(embed_dims, num_chars, encoder_dims,
                                encoder_K, num_highways, dropout)
         self.encoder_proj = nn.Linear(decoder_dims, decoder_dims, bias=False)
         self.decoder = Decoder(n_mels, decoder_dims, lstm_dims)
@@ -297,7 +297,7 @@ class Tacotron(nn.Module):
         self.num_params()
 
         self.register_buffer('step', torch.zeros(1, dtype=torch.long))
-    
+
     @property
     def r(self):
         return self.decoder.r.item()
@@ -315,119 +315,119 @@ class Tacotron(nn.Module):
             self.eval()
         else:
             self.train()
-        
+
         batch_size, _, steps  = m.size()
-    
+
         # Initialise all hidden states and pack into tuple
         attn_hidden = torch.zeros(batch_size, self.decoder_dims, device=device)
         rnn1_hidden = torch.zeros(batch_size, self.lstm_dims, device=device)
         rnn2_hidden = torch.zeros(batch_size, self.lstm_dims, device=device)
         hidden_states = (attn_hidden, rnn1_hidden, rnn2_hidden)
-        
+
         # Initialise all lstm cell states and pack into tuple
         rnn1_cell = torch.zeros(batch_size, self.lstm_dims, device=device)
         rnn2_cell = torch.zeros(batch_size, self.lstm_dims, device=device)
         cell_states = (rnn1_cell, rnn2_cell)
-        
+
         # <GO> Frame for start of decoder loop
         go_frame = torch.zeros(batch_size, self.n_mels, device=device)
-        
+
         # Need an initial context vector
         context_vec = torch.zeros(batch_size, self.decoder_dims, device=device)
-        
-        # Project the encoder outputs to avoid 
+
+        # Project the encoder outputs to avoid
         # unnecessary matmuls in the decoder loop
         encoder_seq = self.encoder(x)
         encoder_seq_proj = self.encoder_proj(encoder_seq)
-        
+
         # Need a couple of lists for outputs
         mel_outputs, attn_scores = [], []
-        
+
         # Run the decoder loop
         for t in range(0, steps, self.r):
             prenet_in = m[:, :, t - 1] if t > 0 else go_frame
             mel_frames, scores, hidden_states, cell_states, context_vec = \
-                self.decoder(encoder_seq, encoder_seq_proj, prenet_in, 
+                self.decoder(encoder_seq, encoder_seq_proj, prenet_in,
                              hidden_states, cell_states, context_vec, t)
             mel_outputs.append(mel_frames)
             attn_scores.append(scores)
-        
+
         # Concat the mel outputs into sequence
         mel_outputs = torch.cat(mel_outputs, dim=2)
-        
+
         # Post-Process for Linear Spectrograms
         postnet_out = self.postnet(mel_outputs)
         linear = self.post_proj(postnet_out)
         linear = linear.transpose(1, 2)
-        
+
         # For easy visualisation
         attn_scores = torch.cat(attn_scores, 1)
         # attn_scores = attn_scores.cpu().data.numpy()
-            
+
         return mel_outputs, linear, attn_scores
-    
+
     def generate(self, x, steps=2000):
         self.eval()
         device = next(self.parameters()).device  # use same device as parameters
-        
+
         batch_size = 1
         x = torch.as_tensor(x, dtype=torch.long, device=device).unsqueeze(0)
-       
+
         # Need to initialise all hidden states and pack into tuple for tidyness
         attn_hidden = torch.zeros(batch_size, self.decoder_dims, device=device)
         rnn1_hidden = torch.zeros(batch_size, self.lstm_dims, device=device)
         rnn2_hidden = torch.zeros(batch_size, self.lstm_dims, device=device)
         hidden_states = (attn_hidden, rnn1_hidden, rnn2_hidden)
-        
+
         # Need to initialise all lstm cell states and pack into tuple for tidyness
         rnn1_cell = torch.zeros(batch_size, self.lstm_dims, device=device)
         rnn2_cell = torch.zeros(batch_size, self.lstm_dims, device=device)
         cell_states = (rnn1_cell, rnn2_cell)
-        
+
         # Need a <GO> Frame for start of decoder loop
         go_frame = torch.zeros(batch_size, self.n_mels, device=device)
-        
+
         # Need an initial context vector
         context_vec = torch.zeros(batch_size, self.decoder_dims, device=device)
-        
-        # Project the encoder outputs to avoid 
+
+        # Project the encoder outputs to avoid
         # unnecessary matmuls in the decoder loop
         encoder_seq = self.encoder(x)
         encoder_seq_proj = self.encoder_proj(encoder_seq)
-        
+
         # Need a couple of lists for outputs
         mel_outputs, attn_scores = [], []
-        
+
         # Run the decoder loop
         for t in range(0, steps, self.r):
             prenet_in = mel_outputs[-1][:, :, -1] if t > 0 else go_frame
             mel_frames, scores, hidden_states, cell_states, context_vec = \
-            self.decoder(encoder_seq, encoder_seq_proj, prenet_in, 
+            self.decoder(encoder_seq, encoder_seq_proj, prenet_in,
                          hidden_states, cell_states, context_vec, t)
             mel_outputs.append(mel_frames)
             attn_scores.append(scores)
             # Stop the loop if silent frames present
             if (mel_frames < -3.8).all() and t > 10: break
-        
+
         # Concat the mel outputs into sequence
         mel_outputs = torch.cat(mel_outputs, dim=2)
-        
+
         # Post-Process for Linear Spectrograms
         postnet_out = self.postnet(mel_outputs)
         linear = self.post_proj(postnet_out)
-    
-    
+
+
         linear = linear.transpose(1, 2)[0].cpu().data.numpy()
         mel_outputs = mel_outputs[0].cpu().data.numpy()
-        
+
         # For easy visualisation
         attn_scores = torch.cat(attn_scores, 1)
         attn_scores = attn_scores.cpu().data.numpy()[0]
-        
+
         self.train()
-        
+
         return mel_outputs, linear, attn_scores
-    
+
     def init_model(self):
         for p in self.parameters():
             if p.dim() > 1: nn.init.xavier_uniform_(p)
@@ -446,7 +446,13 @@ class Tacotron(nn.Module):
     def load(self, path: Union[str, Path]):
         # Use device of model params as location for loaded state
         device = next(self.parameters()).device
-        self.load_state_dict(torch.load(path, map_location=device), strict=False)
+        state_dict = torch.load(path, map_location=device)
+
+        # Backwards compatibility with old saved models
+        if 'r' in state_dict and not 'decoder.r' in state_dict:
+            self.r = state_dict['r']
+
+        self.load_state_dict(state_dict, strict=False)
 
     def save(self, path: Union[str, Path]):
         # No optimizer argument because saving a model should not include data

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -436,30 +436,12 @@ class Tacotron(nn.Module):
         return self.step.data.item()
 
     def reset_step(self):
-        assert self.step is not None
-        device = next(self.parameters()).device  # use same device as parameters
         # assignment to parameters or buffers is overloaded, updates internal dict entry
-        self.step = torch.zeros(1, dtype=torch.long, device=device)
-
-    def checkpoint(self, path: Union[str, Path], optimizer):
-        # Optimizer can be given as an argument because checkpoint function is
-        # only useful in context of already existing training process.
-        if isinstance(path, str): path = Path(path)
-        k_steps = self.get_step() // 1000
-        self.save(path/f'checkpoint_{k_steps}k_steps.pyt')
-        torch.save(optimizer.state_dict(), path/f'checkpoint_{k_steps}k_steps_optim.pyt')
+        self.step = self.step.data.new_tensor(1)
 
     def log(self, path, msg):
         with open(path, 'a') as f:
             print(msg, file=f)
-
-    def restore(self, path: Union[str, Path]):
-        if not os.path.exists(path):
-            print('\nNew Tacotron Training Session...\n')
-            self.save(path)
-        else:
-            print(f'\nLoading Weights: "{path}"\n')
-            self.load(path)
 
     def load(self, path: Union[str, Path]):
         # Use device of model params as location for loaded state

--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -125,7 +125,7 @@ class CBHG(nn.Module):
         x, _ = self.rnn(x)
         return x
 
-    def _parameters(self):
+    def _flatten_parameters(self):
         """Calls `flatten_parameters` on all the rnns used by the WaveRNN. Used
         to improve efficiency and avoid PyTorch yelling at us."""
         [m.flatten_parameters() for m in self._to_flatten]

--- a/preprocess.py
+++ b/preprocess.py
@@ -20,13 +20,16 @@ def valid_n_workers(num):
     return n
 
 parser = argparse.ArgumentParser(description='Preprocessing for WaveRNN and Tacotron')
-parser.add_argument('--path', '-p', default=hp.wav_path, help='directly point to dataset path (overrides hparams.wav_path')
+parser.add_argument('--path', '-p', help='directly point to dataset path (overrides hparams.wav_path')
 parser.add_argument('--extension', '-e', metavar='EXT', default='.wav', help='file extension to search for in dataset folder')
 parser.add_argument('--num_workers', '-w', metavar='N', type=valid_n_workers, default=cpu_count()-1, help='The number of worker threads to use for preprocessing')
 parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
 args = parser.parse_args()
 
 hp = import_from_file('hparams', args.hp_file)
+if args.path is None:
+    args.path = hp.wav_path
+
 extension = args.extension
 path = args.path
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,7 +1,7 @@
 import glob
 from utils.display import *
 from utils.dsp import *
-import hparams as hp
+from utils import hparams as hp
 from multiprocessing import Pool, cpu_count
 from utils.paths import Paths
 import pickle
@@ -9,7 +9,6 @@ import argparse
 from utils.text.recipes import ljspeech
 from utils.files import get_files
 from pathlib import Path
-from utils import import_from_file
 
 
 # Helper functions for argument types
@@ -26,7 +25,7 @@ parser.add_argument('--num_workers', '-w', metavar='N', type=valid_n_workers, de
 parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
 args = parser.parse_args()
 
-hp = import_from_file('hparams', args.hp_file)
+hp.configure(args.hp_file)  # Load hparams from file
 if args.path is None:
     args.path = hp.wav_path
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -23,7 +23,7 @@ parser = argparse.ArgumentParser(description='Preprocessing for WaveRNN and Taco
 parser.add_argument('--path', '-p', default=hp.wav_path, help='directly point to dataset path (overrides hparams.wav_path')
 parser.add_argument('--extension', '-e', metavar='EXT', default='.wav', help='file extension to search for in dataset folder')
 parser.add_argument('--num_workers', '-w', metavar='N', type=valid_n_workers, default=cpu_count()-1, help='The number of worker threads to use for preprocessing')
-parser.add_argument('--hp_file', '-p', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
+parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
 args = parser.parse_args()
 
 hp = import_from_file('hparams', args.hp_file)

--- a/preprocess.py
+++ b/preprocess.py
@@ -9,6 +9,7 @@ import argparse
 from utils.text.recipes import ljspeech
 from utils.files import get_files
 from pathlib import Path
+from utils import import_from_file
 
 
 # Helper functions for argument types
@@ -22,8 +23,10 @@ parser = argparse.ArgumentParser(description='Preprocessing for WaveRNN and Taco
 parser.add_argument('--path', '-p', default=hp.wav_path, help='directly point to dataset path (overrides hparams.wav_path')
 parser.add_argument('--extension', '-e', metavar='EXT', default='.wav', help='file extension to search for in dataset folder')
 parser.add_argument('--num_workers', '-w', metavar='N', type=valid_n_workers, default=cpu_count()-1, help='The number of worker threads to use for preprocessing')
+parser.add_argument('--hp_file', '-p', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
 args = parser.parse_args()
 
+hp = import_from_file('hparams', args.hp_file)
 extension = args.extension
 path = args.path
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -10,9 +10,17 @@ from utils.text.recipes import ljspeech
 from utils.files import get_files
 
 
+# Helper functions for argument types
+def valid_n_workers(num):
+    n = int(num)
+    if n < 1:
+        raise argparse.ArgumentTypeError('%r must be an integer greater than 0' % num)
+    return n
+
 parser = argparse.ArgumentParser(description='Preprocessing for WaveRNN and Tacotron')
 parser.add_argument('--path', '-p', default=hp.wav_path, help='directly point to dataset path (overrides hparams.wav_path')
-parser.add_argument('--extension', '-e', default='.wav', help='file extension to search for in dataset folder')
+parser.add_argument('--extension', '-e', metavar='EXT', default='.wav', help='file extension to search for in dataset folder')
+parser.add_argument('--num_workers', '-w', metavar='N', type=valid_n_workers, default=cpu_count()-1, help='The number of worker threads to use for preprocessing')
 args = parser.parse_args()
 
 extension = args.extension
@@ -60,17 +68,17 @@ else:
         with open(f'{paths.data}text_dict.pkl', 'wb') as f:
             pickle.dump(text_dict, f)
 
-    n_processes = min(8, cpu_count())
+    n_workers = max(1, args.num_workers)
 
     simple_table([
         ('Sample Rate', hp.sample_rate),
         ('Bit Depth', hp.bits),
         ('Mu Law', hp.mu_law),
         ('Hop Length', hp.hop_length),
-        ('CPU Usage', f'{n_processes}/{cpu_count()}')
+        ('CPU Usage', f'{n_workers}/{cpu_count()}')
     ])
 
-    pool = Pool(processes=n_processes)
+    pool = Pool(processes=n_workers)
     dataset = []
 
     for i, (id, length) in enumerate(pool.imap_unordered(process_wav, wav_files), 1):

--- a/preprocess.py
+++ b/preprocess.py
@@ -60,13 +60,17 @@ else:
         with open(f'{paths.data}text_dict.pkl', 'wb') as f:
             pickle.dump(text_dict, f)
 
-    simple_table([('Sample Rate', hp.sample_rate),
-                  ('Bit Depth', hp.bits),
-                  ('Mu Law', hp.mu_law),
-                  ('Hop Length', hp.hop_length),
-                  ('CPU Count', cpu_count())])
+    n_processes = min(8, cpu_count())
 
-    pool = Pool(processes=cpu_count())
+    simple_table([
+        ('Sample Rate', hp.sample_rate),
+        ('Bit Depth', hp.bits),
+        ('Mu Law', hp.mu_law),
+        ('Hop Length', hp.hop_length),
+        ('CPU Usage', f'{n_processes}/{cpu_count()}')
+    ])
+
+    pool = Pool(processes=n_processes)
     dataset = []
 
     for i, (id, length) in enumerate(pool.imap_unordered(process_wav, wav_files), 1):

--- a/quick_start.py
+++ b/quick_start.py
@@ -100,8 +100,7 @@ if __name__ == "__main__":
     voc_k = voc_model.get_step() // 1000
     tts_k = tts_model.get_step() // 1000
 
-    # TODO: get rid of this hardcoding
-    r = 2
+    r = tts_model.r
 
     simple_table([('WaveRNN', str(voc_k) + 'k'),
                   (f'Tacotron(r={r})', str(tts_k) + 'k'),

--- a/quick_start.py
+++ b/quick_start.py
@@ -119,6 +119,6 @@ if __name__ == "__main__":
         m = torch.tensor(m).unsqueeze(0)
         m = (m + 4) / 8
 
-        voc_model.generate(m, save_path, batched, hp.voc_target, hp.voc_overlap, hp.mu_law)
+        voc_model.generate(m, save_path, batched, target, overlap, hp.mu_law)
 
     print('\n\nDone.\n')

--- a/quick_start.py
+++ b/quick_start.py
@@ -82,7 +82,8 @@ if __name__ == "__main__":
                          lstm_dims=hp.tts_lstm_dims,
                          postnet_K=hp.tts_postnet_K,
                          num_highways=hp.tts_num_highways,
-                         dropout=hp.tts_dropout).to(device)
+                         dropout=hp.tts_dropout,
+                         stop_threshold=hp.tts_stop_threshold).to(device)
 
 
     tts_model.restore('quick_start/tts_weights/latest_weights.pyt')

--- a/quick_start.py
+++ b/quick_start.py
@@ -1,6 +1,6 @@
 import torch
 from models.fatchord_version import WaveRNN
-import hparams as hp
+from utils import hparams as hp
 from utils.text.symbols import symbols
 from models.tacotron import Tacotron
 import argparse

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -8,6 +8,8 @@ from utils.text.symbols import symbols
 from utils.paths import Paths
 from models.tacotron import Tacotron
 import argparse
+from utils import data_parallel_workaround
+import os
 
 
 def np_now(x): return x.detach().cpu().numpy()
@@ -32,7 +34,11 @@ def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
 
             x, m = x.to(device), m.to(device)
 
-            m1_hat, m2_hat, attention = model(x, m)
+            # Parallelize model onto GPUS using workaround due to python bug
+            if device.type == 'cuda' and torch.cuda.device_count() > 1:
+                m1_hat, m2_hat, attention = data_parallel_workaround(model, x, m)
+            else:
+                m1_hat, m2_hat, attention = model(x, m) 
 
             m1_loss = F.l1_loss(m1_hat, m)
             m2_loss = F.l1_loss(m2_hat, m)
@@ -42,9 +48,10 @@ def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
             running_loss += loss.item()
 
             loss.backward()
-
-            if hp.tts_clip_grad_norm:
-                torch.nn.utils.clip_grad_norm_(model.parameters(), hp.tts_clip_grad_norm)
+            if hp.tts_clip_grad_norm is not None:
+                grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), hp.tts_clip_grad_norm)
+                if np.isnan(grad_norm):
+                    print('grad_norm was NaN!')
 
             optimizer.step()
 
@@ -56,7 +63,7 @@ def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
             avg_loss = running_loss / i
 
             if step % hp.tts_checkpoint_every == 0:
-                model.checkpoint(paths.tts_checkpoints)
+                model.checkpoint(paths.tts_checkpoints, optimizer)
 
             if attn_example in ids:
                 idx = ids.index(attn_example)
@@ -66,6 +73,9 @@ def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
             msg = f'| Epoch: {e}/{epochs} ({i}/{total_iters}) | Loss: {avg_loss:#.4} | {speed:#.2} steps/s | Step: {k}k | '
             stream(msg)
 
+        # Must save latest optimizer state to ensure that resuming training
+        # doesn't produce artifacts
+        torch.save(optimizer.state_dict(), paths.tts_latest_optim)
         model.save(paths.tts_latest_weights)
         model.log(paths.tts_log, msg)
         print(' ')
@@ -109,6 +119,10 @@ if __name__ == "__main__":
 
     if not args.force_cpu and torch.cuda.is_available():
         device = torch.device('cuda')
+        for session in hp.tts_schedule:
+            _, _, _, batch_size = session
+            if batch_size % torch.cuda.device_count() != 0:
+                raise ValueError('`batch_size` must be evenly divisible by n_gpus!')
     else:
         device = torch.device('cpu')
     print('Using device:', device)
@@ -137,7 +151,10 @@ if __name__ == "__main__":
 
     # model.set_r(hp.tts_r)
 
-    optimiser = optim.Adam(model.parameters())
+    optimizer = optim.Adam(model.parameters())
+    if os.path.isfile(paths.tts_latest_optim):
+        print(f'Loading Optimizer State: "{paths.tts_latest_optim}"')
+        optimizer.load_state_dict(torch.load(paths.tts_latest_optim))
 
     current_step = model.get_step()
 
@@ -160,7 +177,7 @@ if __name__ == "__main__":
                               ('Learning Rate', lr),
                               ('Outputs/Step (r)', model.get_r())])
 
-                tts_train_loop(model, optimiser, train_set, lr, training_steps, attn_example)
+                tts_train_loop(model, optimizer, train_set, lr, training_steps, attn_example)
 
         print('Training Complete.')
         print('To continue training increase tts_total_steps in hparams.py or use --force_train\n')

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -141,7 +141,7 @@ def tts_train_loop(paths, model: Tacotron, optimizer, train_set, lr, train_steps
             if step % hp.tts_checkpoint_every == 0:
                 ckpt_name = f'taco_step{k}K'
                 save_checkpoint(paths, model, optimizer,
-                                name=ckpt_name, is_silent=False)
+                                name=ckpt_name, is_silent=True)
 
             if attn_example in ids:
                 idx = ids.index(attn_example)

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -24,7 +24,7 @@ def main():
     parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
     parser.add_argument('--force_gta', '-g', action='store_true', help='Force the model to create GTA features')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
-    parser.add_argument('--hp_file', '-p', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
+    parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
     args = parser.parse_args()
 
     hp = import_from_file('hparams', args.hp_file)   

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -15,7 +15,7 @@ import os
 def np_now(x): return x.detach().cpu().numpy()
 
 
-def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
+def tts_train_loop(model: Tacotron, optimizer, train_set, lr, train_steps, attn_example):
     device = next(model.parameters()).device  # use same device as model parameters
 
     for p in optimizer.param_groups: p['lr'] = lr
@@ -81,7 +81,7 @@ def tts_train_loop(model, optimizer, train_set, lr, train_steps, attn_example):
         print(' ')
 
 
-def create_gta_features(model, train_set, save_path):
+def create_gta_features(model: Tacotron, train_set, save_path):
     device = next(model.parameters()).device  # use same device as model parameters
 
     iters = len(train_set)
@@ -168,14 +168,14 @@ if __name__ == "__main__":
 
                 train_set, attn_example = get_tts_dataset(paths.data, batch_size, r)
 
-                model.set_r(r)
+                model.r = r
 
                 training_steps = max_step - current_step
 
                 simple_table([(f'Steps with r={r}', str(training_steps//1000) + 'k Steps'),
                               ('Batch Size', batch_size),
                               ('Learning Rate', lr),
-                              ('Outputs/Step (r)', model.get_r())])
+                              ('Outputs/Step (r)', model.r)])
 
                 tts_train_loop(model, optimizer, train_set, lr, training_steps, attn_example)
 
@@ -185,7 +185,7 @@ if __name__ == "__main__":
 
     print('Creating Ground Truth Aligned Dataset...\n')
 
-    train_set, attn_example = get_tts_dataset(paths.data, 8, model.get_r())
+    train_set, attn_example = get_tts_dataset(paths.data, 8, model.r)
     create_gta_features(model, train_set, paths.gta)
 
     print('\n\nYou can now train WaveRNN on GTA features - use python train_wavernn.py --gta\n')

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -76,7 +76,7 @@ def main():
                               ('Outputs/Step (r)', model.r)])
 
                 train_set, attn_example = get_tts_datasets(paths.data, batch_size, r)
-                tts_train_loop(model, optimizer, train_set, lr, training_steps, attn_example)
+                tts_train_loop(paths, model, optimizer, train_set, lr, training_steps, attn_example)
 
         print('Training Complete.')
         print('To continue training increase tts_total_steps in hparams.py or use --force_train\n')
@@ -90,7 +90,7 @@ def main():
     print('\n\nYou can now train WaveRNN on GTA features - use python train_wavernn.py --gta\n')
 
 
-def tts_train_loop(model: Tacotron, optimizer, train_set, lr, train_steps, attn_example):
+def tts_train_loop(paths, model: Tacotron, optimizer, train_set, lr, train_steps, attn_example):
     device = next(model.parameters()).device  # use same device as model parameters
 
     for g in optimizer.param_groups: g['lr'] = lr

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -69,7 +69,7 @@ def tts_train_loop(model: Tacotron, optimizer, train_set, lr, train_steps, attn_
 
             if attn_example in ids:
                 idx = ids.index(attn_example)
-                save_attention(attention[idx][:, :160], paths.tts_attention/f'{step}')
+                save_attention(np_now(attention[idx][:, :160]), paths.tts_attention/f'{step}')
                 save_spectrogram(np_now(m2_hat[idx]), paths.tts_mel_plot/f'{step}', 600)
 
             msg = f'| Epoch: {e}/{epochs} ({i}/{total_iters}) | Loss: {avg_loss:#.4} | {speed:#.2} steps/s | Step: {k}k | '

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -171,7 +171,7 @@ def create_gta_features(model: Tacotron, train_set, save_path: Path):
 
         gta = gta.cpu().numpy()
 
-        for j, item_id in enumerate(len(ids)):
+        for j, item_id in enumerate(ids):
             mel = gta[j][:, :mel_lens[j]]
             mel = (mel + 4) / 8
             np.save(save_path/f'{item_id}.npy', mel, allow_pickle=False)

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -63,10 +63,10 @@ def main():
     optimizer = optim.Adam(model.parameters())
     restore_checkpoint(paths, model, optimizer, create_if_missing=True)
 
-    current_step = model.get_step()
-
     if not force_gta:
         for i, session in enumerate(hp.tts_schedule):
+            current_step = model.get_step()
+
             r, lr, max_step, batch_size = session
 
             training_steps = max_step - current_step

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -56,7 +56,8 @@ def main():
                      lstm_dims=hp.tts_lstm_dims,
                      postnet_K=hp.tts_postnet_K,
                      num_highways=hp.tts_num_highways,
-                     dropout=hp.tts_dropout).to(device)
+                     dropout=hp.tts_dropout,
+                     stop_threshold=hp.tts_stop_threshold).to(device)
 
     optimizer = optim.Adam(model.parameters())
     restore_checkpoint(paths, model, optimizer, create_if_missing=True)

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -11,6 +11,7 @@ import argparse
 from utils import data_parallel_workaround
 import os
 from pathlib import Path
+import time
 
 
 def np_now(x: torch.Tensor): return x.detach().cpu().numpy()

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
 
     optimizer = optim.Adam(model.parameters())
     if os.path.isfile(paths.tts_latest_optim):
-        print(f'Loading Optimizer State: "{paths.tts_latest_optim}"')
+        print(f'Loading Optimizer State: "{paths.tts_latest_optim}"\n')
         optimizer.load_state_dict(torch.load(paths.tts_latest_optim))
 
     current_step = model.get_step()

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -12,9 +12,96 @@ from utils import data_parallel_workaround
 import os
 from pathlib import Path
 import time
+import numpy as np
 
 
 def np_now(x: torch.Tensor): return x.detach().cpu().numpy()
+
+
+if __name__ == "__main__":
+
+    # Parse Arguments
+    parser = argparse.ArgumentParser(description='Train Tacotron TTS')
+    parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
+    parser.add_argument('--force_gta', '-g', action='store_true', help='Force the model to create GTA features')
+    parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
+    args = parser.parse_args()
+
+    force_train = args.force_train
+    force_gta = args.force_gta
+
+    if not args.force_cpu and torch.cuda.is_available():
+        device = torch.device('cuda')
+        for session in hp.tts_schedule:
+            _, _, _, batch_size = session
+            if batch_size % torch.cuda.device_count() != 0:
+                raise ValueError('`batch_size` must be evenly divisible by n_gpus!')
+    else:
+        device = torch.device('cpu')
+    print('Using device:', device)
+
+    print('\nInitialising Tacotron Model...\n')
+
+    # Instantiate Tacotron Model
+    model = Tacotron(embed_dims=hp.tts_embed_dims,
+                     num_chars=len(symbols),
+                     encoder_dims=hp.tts_encoder_dims,
+                     decoder_dims=hp.tts_decoder_dims,
+                     n_mels=hp.num_mels,
+                     fft_bins=hp.num_mels,
+                     postnet_dims=hp.tts_postnet_dims,
+                     encoder_K=hp.tts_encoder_K,
+                     lstm_dims=hp.tts_lstm_dims,
+                     postnet_K=hp.tts_postnet_K,
+                     num_highways=hp.tts_num_highways,
+                     dropout=hp.tts_dropout).to(device=device)
+
+    paths = Paths(hp.data_path, hp.voc_model_id, hp.tts_model_id)
+
+    model.restore(paths.tts_latest_weights)
+
+    # model.reset_step()
+
+    # model.set_r(hp.tts_r)
+
+    optimizer = optim.Adam(model.parameters())
+    if paths.tts_latest_optim.exists():
+        print(f'Loading Optimizer State: "{paths.tts_latest_optim}"\n')
+        optimizer.load_state_dict(torch.load(paths.tts_latest_optim))
+
+    current_step = model.get_step()
+
+    if not force_gta:
+
+        for session in hp.tts_schedule:
+
+            r, lr, max_step, batch_size = session
+
+            if current_step < max_step:
+
+                train_set, attn_example = get_tts_datasets(paths.data, batch_size, r)
+
+                model.r = r
+
+                training_steps = max_step - current_step
+
+                simple_table([(f'Steps with r={r}', str(training_steps//1000) + 'k Steps'),
+                              ('Batch Size', batch_size),
+                              ('Learning Rate', lr),
+                              ('Outputs/Step (r)', model.r)])
+
+                tts_train_loop(model, optimizer, train_set, lr, training_steps, attn_example)
+
+        print('Training Complete.')
+        print('To continue training increase tts_total_steps in hparams.py or use --force_train\n')
+
+
+    print('Creating Ground Truth Aligned Dataset...\n')
+
+    train_set, attn_example = get_tts_datasets(paths.data, 8, model.r)
+    create_gta_features(model, train_set, paths.gta)
+
+    print('\n\nYou can now train WaveRNN on GTA features - use python train_wavernn.py --gta\n')
 
 
 def tts_train_loop(model: Tacotron, optimizer, train_set, lr, train_steps, attn_example):
@@ -106,87 +193,90 @@ def create_gta_features(model: Tacotron, train_set, save_path: Path):
         stream(msg)
 
 
-if __name__ == "__main__":
+def save_checkpoint(paths: Paths, model: Tacotron, optimizer, name=None):
+    """Saves the training session to disk.
 
-    # Parse Arguments
-    parser = argparse.ArgumentParser(description='Train Tacotron TTS')
-    parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
-    parser.add_argument('--force_gta', '-g', action='store_true', help='Force the model to create GTA features')
-    parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
-    args = parser.parse_args()
+    Args:
+        paths:  Provides information about the different paths to use.
+        model:  A `Tacotron` model to save the parameters and buffers from.
+        optimizer:  An optmizer to save the state of (momentum, etc).
+        name:  If provided, will name to a checkpoint with the given name. Note
+            that regardless of whether this is provided or not, this function
+            will always update the files specified in `paths` that give the
+            location of the latest weights and optimizer state. Saving
+            a named checkpoint happens in addition to this update.
+    """    
+    def helper(path_dict, is_named):
+        s = 'named' if is_named else 'latest'
+        num_exist = sum(p.exists() for p in path_dict.values())
+        
+        if num_exist not in (0,2):
+            # Checkpoint broken
+            raise FileNotFoundError(
+                f'We expected either both or no files in the {s} checkpoint to '
+                'exist, but instead we got exactly one!')
+        
+        if num_exist == 0:
+            print('Creating {s} checkpoint...')
+            for p in path_dict.values():
+                p.parent.mkdir(parents=True)
+        else:
+            print('Saving to existing {s} checkpoint...')
+        
+        print(f'Saving {s} weights: {path_dict["w"]}')
+        model.save(path_dict['w'])
+        print(f'Saving {s} optimizer state: {path_dict["o"]}')
+        torch.save(optimizer.state_dict(), path_dict['o'])    
+    
+    latest_paths = {'w': paths.tts_latest_weights, 'o': paths.tts_latest_optim}
+    helper(latest_paths, False)
 
-    force_train = args.force_train
-    force_gta = args.force_gta
+    if name:
+        named_paths ={
+            'w': paths.tts_checkpoints/f'{name}_weights.pyt',
+            'o': paths.tts_checkpoints/f'{name}_optim.pyt',
+        }
+        helper(named_paths, True)
 
-    if not args.force_cpu and torch.cuda.is_available():
-        device = torch.device('cuda')
-        for session in hp.tts_schedule:
-            _, _, _, batch_size = session
-            if batch_size % torch.cuda.device_count() != 0:
-                raise ValueError('`batch_size` must be evenly divisible by n_gpus!')
+
+def restore_checkpoint(paths: Paths, model: Tacotron, optimizer, name=None, create_if_missing=False):
+    """Restores from a training session saved to disk.
+
+    Args:
+        paths:  Provides information about the different paths to use.
+        model:  A `Tacotron` model to save the parameters and buffers from.
+        optimizer:  An optmizer to save the state of (momentum, etc).
+        name:  If provided, will restore from a checkpoint with the given name.
+            Otherwise, will restore from the latest weights and optimizer state
+            as specified in `paths`.
+        create_if_missing:  If `True`, will create the checkpoint if it doesn't
+            yet exist, as well as update the files specified in `paths` that
+            give the location of the current latest weights and optimizer state.
+            If `False` and the checkpoint doesn't exist, will raise a 
+            `FileNotFoundError`.
+    """
+    if name:
+        path_dict = {
+            'w': paths.tts_checkpoints/f'{name}_weights.pyt',
+            'o': paths.tts_checkpoints/f'{name}_optim.pyt',
+        }
+        s = 'named'
     else:
-        device = torch.device('cpu')
-    print('Using device:', device)
-
-    print('\nInitialising Tacotron Model...\n')
-
-    # Instantiate Tacotron Model
-    model = Tacotron(embed_dims=hp.tts_embed_dims,
-                     num_chars=len(symbols),
-                     encoder_dims=hp.tts_encoder_dims,
-                     decoder_dims=hp.tts_decoder_dims,
-                     n_mels=hp.num_mels,
-                     fft_bins=hp.num_mels,
-                     postnet_dims=hp.tts_postnet_dims,
-                     encoder_K=hp.tts_encoder_K,
-                     lstm_dims=hp.tts_lstm_dims,
-                     postnet_K=hp.tts_postnet_K,
-                     num_highways=hp.tts_num_highways,
-                     dropout=hp.tts_dropout).to(device=device)
-
-    paths = Paths(hp.data_path, hp.voc_model_id, hp.tts_model_id)
-
-    model.restore(paths.tts_latest_weights)
-
-    # model.reset_step()
-
-    # model.set_r(hp.tts_r)
-
-    optimizer = optim.Adam(model.parameters())
-    if paths.tts_latest_optim.exists():
-        print(f'Loading Optimizer State: "{paths.tts_latest_optim}"\n')
-        optimizer.load_state_dict(torch.load(paths.tts_latest_optim))
-
-    current_step = model.get_step()
-
-    if not force_gta:
-
-        for session in hp.tts_schedule:
-
-            r, lr, max_step, batch_size = session
-
-            if current_step < max_step:
-
-                train_set, attn_example = get_tts_datasets(paths.data, batch_size, r)
-
-                model.r = r
-
-                training_steps = max_step - current_step
-
-                simple_table([(f'Steps with r={r}', str(training_steps//1000) + 'k Steps'),
-                              ('Batch Size', batch_size),
-                              ('Learning Rate', lr),
-                              ('Outputs/Step (r)', model.r)])
-
-                tts_train_loop(model, optimizer, train_set, lr, training_steps, attn_example)
-
-        print('Training Complete.')
-        print('To continue training increase tts_total_steps in hparams.py or use --force_train\n')
-
-
-    print('Creating Ground Truth Aligned Dataset...\n')
-
-    train_set, attn_example = get_tts_datasets(paths.data, 8, model.r)
-    create_gta_features(model, train_set, paths.gta)
-
-    print('\n\nYou can now train WaveRNN on GTA features - use python train_wavernn.py --gta\n')
+        path_dict = {
+            'w': paths.tts_latest_weights,
+            'o': paths.tts_latest_optim
+        }
+        s = 'latest'
+    
+    num_exist = sum(p.exists() for p in path_dict.values())
+    if num_exist == 2:
+        # Checkpoint exists
+        print(f'Restoring from {s} checkpoint...')
+        print(f'Loading {s} weights: {path_dict["w"]}')
+        model.load(path_dict['w'])
+        print(f'Loading {s} optimizer state: {path_dict["o"]}')
+        optimizer.load_state_dict(torch.load())
+    elif create_if_missing:
+        save_checkpoint(paths, model, optimizer, name)
+    else:
+        raise FileNotFoundError(f'The {s} checkpoint could not be found!')

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -232,6 +232,10 @@ def restore_checkpoint(paths: Paths, model: Tacotron, optimizer, *,
         name=None, create_if_missing=False):
     """Restores from a training session saved to disk.
 
+    NOTE: The optimizer's state is placed on the same device as it's model
+    parameters. Therefore, be sure you have done `model.to(device)` before
+    calling this method.
+
     Args:
         paths:  Provides information about the different paths to use.
         model:  A `Tacotron` model to save the parameters and buffers from.

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -1,7 +1,7 @@
 import torch
 from torch import optim
 import torch.nn.functional as F
-from utils import import_from_file
+from utils import hparams as hp
 from utils.display import *
 from utils.dataset import get_tts_datasets
 from utils.text.symbols import symbols
@@ -27,7 +27,7 @@ def main():
     parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
     args = parser.parse_args()
 
-    hp = import_from_file('hparams', args.hp_file)   
+    hp.configure(args.hp_file)  # Load hparams from file.
     paths = Paths(hp.data_path, hp.voc_model_id, hp.tts_model_id)
 
     force_train = args.force_train

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -1,9 +1,9 @@
 import torch
 from torch import optim
 import torch.nn.functional as F
+from utils import import_from_file
 from utils.display import *
 from utils.dataset import get_tts_datasets
-import hparams as hp
 from utils.text.symbols import symbols
 from utils.paths import Paths
 from models.tacotron import Tacotron
@@ -24,8 +24,10 @@ def main():
     parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
     parser.add_argument('--force_gta', '-g', action='store_true', help='Force the model to create GTA features')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
+    parser.add_argument('--hp_file', '-p', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
     args = parser.parse_args()
 
+    hp = import_from_file('hparams', args.hp_file)   
     paths = Paths(hp.data_path, hp.voc_model_id, hp.tts_model_id)
 
     force_train = args.force_train

--- a/train_tacotron.py
+++ b/train_tacotron.py
@@ -116,7 +116,7 @@ def tts_train_loop(paths: Paths, model: Tacotron, optimizer, train_set, lr, trai
     total_iters = len(train_set)
     epochs = train_steps // total_iters + 1
 
-    for e in range(epochs):
+    for e in range(1, epochs+1):
 
         start = time.time()
         running_loss = 0

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -12,7 +12,6 @@ from gen_wavernn import gen_testset
 from utils.paths import Paths
 import argparse
 from utils import data_parallel_workaround
-import os
 
 
 def main():
@@ -205,6 +204,10 @@ def save_checkpoint(paths: Paths, model: WaveRNN, optimizer, *,
 def restore_checkpoint(paths: Paths, model: WaveRNN, optimizer, *,
         name=None, create_if_missing=False):
     """Restores from a training session saved to disk.
+
+    NOTE: The optimizer's state is placed on the same device as it's model
+    parameters. Therefore, be sure you have done `model.to(device)` before
+    calling this method.
 
     Args:
         paths:  Provides information about the different paths to use.

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -15,7 +15,7 @@ from utils import data_parallel_workaround
 import os
 
 
-def voc_train_loop(model, loss_func, optimizer, train_set, test_set, lr, total_steps):
+def voc_train_loop(model: WaveRNN, loss_func, optimizer, train_set, test_set, lr, total_steps):
     # Use same device as model parameters
     device = next(model.parameters()).device
     
@@ -56,6 +56,7 @@ def voc_train_loop(model, loss_func, optimizer, train_set, test_set, lr, total_s
                 if np.isnan(grad_norm):
                     print('grad_norm was NaN!')
             optimizer.step()
+            
             running_loss += loss.item()
 
             speed = i / (time.time() - start)

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -3,6 +3,7 @@ import numpy as np
 import torch
 from torch import optim
 import torch.nn.functional as F
+from utils import import_from_file
 from utils.display import stream, simple_table
 from utils.dataset import get_vocoder_datasets
 from utils.distribution import discretized_mix_logistic_loss
@@ -81,7 +82,7 @@ def voc_train_loop(model: WaveRNN, loss_func, optimizer, train_set, test_set, lr
         print(' ')
 
 
-if __name__ == "__main__":
+def main():
 
     # Parse Arguments
     parser = argparse.ArgumentParser(description='Train WaveRNN Vocoder')
@@ -90,10 +91,15 @@ if __name__ == "__main__":
     parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
     parser.add_argument('--gta', '-g', action='store_true', help='train wavernn on GTA features')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
-    parser.set_defaults(lr=hp.voc_lr)
-    parser.set_defaults(batch_size=hp.voc_batch_size)
+    parser.add_argument('--hp_file', '-p', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
     args = parser.parse_args()
 
+    hp = import_from_file('hparams', args.hp_file)
+    if args.lr is None:
+        args.lr = hp.voc_lr
+    if args.batch_size is None:
+        args.batch_size = hp.voc_batch_size
+    
     batch_size = args.batch_size
     force_train = args.force_train
     train_gta = args.gta
@@ -151,3 +157,6 @@ if __name__ == "__main__":
 
     print('Training Complete.')
     print('To continue training increase voc_total_steps in hparams.py or use --force_train')
+
+if __name__ == "__main__":
+    main()

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
     optimizer = optim.Adam(voc_model.parameters())
     if os.path.isfile(paths.voc_latest_optim):
-        print(f'Loading Optimizer State: "{paths.voc_latest_optim}"')
+        print(f'Loading Optimizer State: "{paths.voc_latest_optim}"\n')
         optimizer.load_state_dict(torch.load(paths.voc_latest_optim))
 
     train_set, test_set = get_vocoder_datasets(paths.data, batch_size, train_gta)

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -12,6 +12,7 @@ from gen_wavernn import gen_testset
 from utils.paths import Paths
 import argparse
 from utils import data_parallel_workaround
+from utils.checkpoints import save_checkpoint, restore_checkpoint
 
 
 def main():
@@ -67,7 +68,7 @@ def main():
     assert np.cumprod(hp.voc_upsample_factors)[-1] == hp.hop_length
 
     optimizer = optim.Adam(voc_model.parameters())
-    restore_checkpoint(paths, voc_model, optimizer, create_if_missing=True)
+    restore_checkpoint('voc', paths, voc_model, optimizer, create_if_missing=True)
 
     train_set, test_set = get_vocoder_datasets(paths.data, batch_size, train_gta)
 
@@ -141,7 +142,7 @@ def voc_train_loop(paths: Paths, model: WaveRNN, loss_func, optimizer, train_set
                 gen_testset(model, test_set, hp.voc_gen_at_checkpoint, hp.voc_gen_batched,
                             hp.voc_target, hp.voc_overlap, paths.voc_output)
                 ckpt_name = f'wave_step{k}K'
-                save_checkpoint(paths, model, optimizer,
+                save_checkpoint('voc', paths, model, optimizer,
                                 name=ckpt_name, is_silent=True)
 
             msg = f'| Epoch: {e}/{epochs} ({i}/{total_iters}) | Loss: {avg_loss:.4f} | {speed:.1f} steps/s | Step: {k}k | '
@@ -149,104 +150,9 @@ def voc_train_loop(paths: Paths, model: WaveRNN, loss_func, optimizer, train_set
 
         # Must save latest optimizer state to ensure that resuming training
         # doesn't produce artifacts
-        save_checkpoint(paths, model, optimizer, is_silent=True)
+        save_checkpoint('voc', paths, model, optimizer, is_silent=True)
         model.log(paths.voc_log, msg)
         print(' ')
-
-
-def save_checkpoint(paths: Paths, model: WaveRNN, optimizer, *,
-        name=None, is_silent=False):
-    """Saves the training session to disk.
-
-    Args:
-        paths:  Provides information about the different paths to use.
-        model:  A `WaveRNN` model to save the parameters and buffers from.
-        optimizer:  An optmizer to save the state of (momentum, etc).
-        name:  If provided, will name to a checkpoint with the given name. Note
-            that regardless of whether this is provided or not, this function
-            will always update the files specified in `paths` that give the
-            location of the latest weights and optimizer state. Saving
-            a named checkpoint happens in addition to this update.
-    """
-    def helper(path_dict, is_named):
-        s = 'named' if is_named else 'latest'
-        num_exist = sum(p.exists() for p in path_dict.values())
-
-        if num_exist not in (0,2):
-            # Checkpoint broken
-            raise FileNotFoundError(
-                f'We expected either both or no files in the {s} checkpoint to '
-                'exist, but instead we got exactly one!')
-
-        if num_exist == 0:
-            if not is_silent: print(f'Creating {s} checkpoint...')
-            for p in path_dict.values():
-                p.parent.mkdir(parents=True, exist_ok=True)
-        else:
-            if not is_silent: print(f'Saving to existing {s} checkpoint...')
-
-        if not is_silent: print(f'Saving {s} weights: {path_dict["w"]}')
-        model.save(path_dict['w'])
-        if not is_silent: print(f'Saving {s} optimizer state: {path_dict["o"]}')
-        torch.save(optimizer.state_dict(), path_dict['o'])
-
-    latest_paths = {'w': paths.voc_latest_weights, 'o': paths.voc_latest_optim}
-    helper(latest_paths, False)
-
-    if name:
-        named_paths ={
-            'w': paths.voc_checkpoints/f'{name}_weights.pyt',
-            'o': paths.voc_checkpoints/f'{name}_optim.pyt',
-        }
-        helper(named_paths, True)
-
-
-def restore_checkpoint(paths: Paths, model: WaveRNN, optimizer, *,
-        name=None, create_if_missing=False):
-    """Restores from a training session saved to disk.
-
-    NOTE: The optimizer's state is placed on the same device as it's model
-    parameters. Therefore, be sure you have done `model.to(device)` before
-    calling this method.
-
-    Args:
-        paths:  Provides information about the different paths to use.
-        model:  A `WaveRNN` model to save the parameters and buffers from.
-        optimizer:  An optmizer to save the state of (momentum, etc).
-        name:  If provided, will restore from a checkpoint with the given name.
-            Otherwise, will restore from the latest weights and optimizer state
-            as specified in `paths`.
-        create_if_missing:  If `True`, will create the checkpoint if it doesn't
-            yet exist, as well as update the files specified in `paths` that
-            give the location of the current latest weights and optimizer state.
-            If `False` and the checkpoint doesn't exist, will raise a
-            `FileNotFoundError`.
-    """
-    if name:
-        path_dict = {
-            'w': paths.voc_checkpoints/f'{name}_weights.pyt',
-            'o': paths.voc_checkpoints/f'{name}_optim.pyt',
-        }
-        s = 'named'
-    else:
-        path_dict = {
-            'w': paths.voc_latest_weights,
-            'o': paths.voc_latest_optim
-        }
-        s = 'latest'
-
-    num_exist = sum(p.exists() for p in path_dict.values())
-    if num_exist == 2:
-        # Checkpoint exists
-        print(f'Restoring from {s} checkpoint...')
-        print(f'Loading {s} weights: {path_dict["w"]}')
-        model.load(path_dict['w'])
-        print(f'Loading {s} optimizer state: {path_dict["o"]}')
-        optimizer.load_state_dict(torch.load(path_dict['o']))
-    elif create_if_missing:
-        save_checkpoint(paths, model, optimizer, name=name, is_silent=False)
-    else:
-        raise FileNotFoundError(f'The {s} checkpoint could not be found!')
 
 
 if __name__ == "__main__":

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -15,11 +15,84 @@ from utils import data_parallel_workaround
 import os
 
 
-def voc_train_loop(model: WaveRNN, loss_func, optimizer, train_set, test_set, lr, total_steps):
+def main():
+
+    # Parse Arguments
+    parser = argparse.ArgumentParser(description='Train WaveRNN Vocoder')
+    parser.add_argument('--lr', '-l', type=float,  help='[float] override hparams.py learning rate')
+    parser.add_argument('--batch_size', '-b', type=int, help='[int] override hparams.py batch size')
+    parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
+    parser.add_argument('--gta', '-g', action='store_true', help='train wavernn on GTA features')
+    parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
+    parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
+    args = parser.parse_args()
+
+    hp.configure(args.hp_file)  # load hparams from file
+    if args.lr is None:
+        args.lr = hp.voc_lr
+    if args.batch_size is None:
+        args.batch_size = hp.voc_batch_size
+
+    paths = Paths(hp.data_path, hp.voc_model_id, hp.tts_model_id)
+
+    batch_size = args.batch_size
+    force_train = args.force_train
+    train_gta = args.gta
+    lr = args.lr
+
+    if not args.force_cpu and torch.cuda.is_available():
+        device = torch.device('cuda')
+        if batch_size % torch.cuda.device_count() != 0:
+            raise ValueError('`batch_size` must be evenly divisible by n_gpus!')
+    else:
+        device = torch.device('cpu')
+    print('Using device:', device)
+
+    print('\nInitialising Model...\n')
+
+    # Instantiate WaveRNN Model
+    voc_model = WaveRNN(rnn_dims=hp.voc_rnn_dims,
+                        fc_dims=hp.voc_fc_dims,
+                        bits=hp.bits,
+                        pad=hp.voc_pad,
+                        upsample_factors=hp.voc_upsample_factors,
+                        feat_dims=hp.num_mels,
+                        compute_dims=hp.voc_compute_dims,
+                        res_out_dims=hp.voc_res_out_dims,
+                        res_blocks=hp.voc_res_blocks,
+                        hop_length=hp.hop_length,
+                        sample_rate=hp.sample_rate,
+                        mode=hp.voc_mode).to(device)
+
+    # Check to make sure the hop length is correctly factorised
+    assert np.cumprod(hp.voc_upsample_factors)[-1] == hp.hop_length
+
+    optimizer = optim.Adam(voc_model.parameters())
+    restore_checkpoint(paths, voc_model, optimizer, create_if_missing=True)
+
+    train_set, test_set = get_vocoder_datasets(paths.data, batch_size, train_gta)
+
+    total_steps = 10_000_000 if force_train else hp.voc_total_steps
+
+    simple_table([('Remaining', str((total_steps - voc_model.get_step())//1000) + 'k Steps'),
+                  ('Batch Size', batch_size),
+                  ('LR', lr),
+                  ('Sequence Len', hp.voc_seq_len),
+                  ('GTA Train', train_gta)])
+
+    loss_func = F.cross_entropy if voc_model.mode == 'RAW' else discretized_mix_logistic_loss
+
+    voc_train_loop(paths, voc_model, loss_func, optimizer, train_set, test_set, lr, total_steps)
+
+    print('Training Complete.')
+    print('To continue training increase voc_total_steps in hparams.py or use --force_train')
+
+
+def voc_train_loop(paths: Paths, model: WaveRNN, loss_func, optimizer, train_set, test_set, lr, total_steps):
     # Use same device as model parameters
     device = next(model.parameters()).device
 
-    for p in optimizer.param_groups: p['lr'] = lr
+    for g in optimizer.param_groups: g['lr'] = lr
 
     total_iters = len(train_set)
     epochs = (total_steps - model.get_step()) // total_iters + 1
@@ -58,9 +131,9 @@ def voc_train_loop(model: WaveRNN, loss_func, optimizer, train_set, test_set, lr
             optimizer.step()
 
             running_loss += loss.item()
+            avg_loss = running_loss / i
 
             speed = i / (time.time() - start)
-            avg_loss = running_loss / i
 
             step = model.get_step()
             k = step // 1000
@@ -68,94 +141,110 @@ def voc_train_loop(model: WaveRNN, loss_func, optimizer, train_set, test_set, lr
             if step % hp.voc_checkpoint_every == 0:
                 gen_testset(model, test_set, hp.voc_gen_at_checkpoint, hp.voc_gen_batched,
                             hp.voc_target, hp.voc_overlap, paths.voc_output)
-                model.checkpoint(paths.voc_checkpoints, optimizer)
+                ckpt_name = f'wave_step{k}K'
+                save_checkpoint(paths, model, optimizer,
+                                name=ckpt_name, is_silent=True)
 
             msg = f'| Epoch: {e}/{epochs} ({i}/{total_iters}) | Loss: {avg_loss:.4f} | {speed:.1f} steps/s | Step: {k}k | '
             stream(msg)
 
         # Must save latest optimizer state to ensure that resuming training
         # doesn't produce artifacts
-        torch.save(optimizer.state_dict(), paths.voc_latest_optim)
-        model.save(paths.voc_latest_weights)
+        save_checkpoint(paths, model, optimizer, is_silent=True)
         model.log(paths.voc_log, msg)
         print(' ')
 
 
-def main():
+def save_checkpoint(paths: Paths, model: WaveRNN, optimizer, *,
+        name=None, is_silent=False):
+    """Saves the training session to disk.
 
-    # Parse Arguments
-    parser = argparse.ArgumentParser(description='Train WaveRNN Vocoder')
-    parser.add_argument('--lr', '-l', type=float,  help='[float] override hparams.py learning rate')
-    parser.add_argument('--batch_size', '-b', type=int, help='[int] override hparams.py batch size')
-    parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
-    parser.add_argument('--gta', '-g', action='store_true', help='train wavernn on GTA features')
-    parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
-    parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
-    args = parser.parse_args()
+    Args:
+        paths:  Provides information about the different paths to use.
+        model:  A `WaveRNN` model to save the parameters and buffers from.
+        optimizer:  An optmizer to save the state of (momentum, etc).
+        name:  If provided, will name to a checkpoint with the given name. Note
+            that regardless of whether this is provided or not, this function
+            will always update the files specified in `paths` that give the
+            location of the latest weights and optimizer state. Saving
+            a named checkpoint happens in addition to this update.
+    """
+    def helper(path_dict, is_named):
+        s = 'named' if is_named else 'latest'
+        num_exist = sum(p.exists() for p in path_dict.values())
 
-    hp.configure(args.hp_file)  # load hparams from file
-    if args.lr is None:
-        args.lr = hp.voc_lr
-    if args.batch_size is None:
-        args.batch_size = hp.voc_batch_size
+        if num_exist not in (0,2):
+            # Checkpoint broken
+            raise FileNotFoundError(
+                f'We expected either both or no files in the {s} checkpoint to '
+                'exist, but instead we got exactly one!')
 
-    batch_size = args.batch_size
-    force_train = args.force_train
-    train_gta = args.gta
-    lr = args.lr
+        if num_exist == 0:
+            if not is_silent: print(f'Creating {s} checkpoint...')
+            for p in path_dict.values():
+                p.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            if not is_silent: print(f'Saving to existing {s} checkpoint...')
 
-    if not args.force_cpu and torch.cuda.is_available():
-        device = torch.device('cuda')
-        if batch_size % torch.cuda.device_count() != 0:
-            raise ValueError('`batch_size` must be evenly divisible by n_gpus!')
+        if not is_silent: print(f'Saving {s} weights: {path_dict["w"]}')
+        model.save(path_dict['w'])
+        if not is_silent: print(f'Saving {s} optimizer state: {path_dict["o"]}')
+        torch.save(optimizer.state_dict(), path_dict['o'])
+
+    latest_paths = {'w': paths.voc_latest_weights, 'o': paths.voc_latest_optim}
+    helper(latest_paths, False)
+
+    if name:
+        named_paths ={
+            'w': paths.voc_checkpoints/f'{name}_weights.pyt',
+            'o': paths.voc_checkpoints/f'{name}_optim.pyt',
+        }
+        helper(named_paths, True)
+
+
+def restore_checkpoint(paths: Paths, model: WaveRNN, optimizer, *,
+        name=None, create_if_missing=False):
+    """Restores from a training session saved to disk.
+
+    Args:
+        paths:  Provides information about the different paths to use.
+        model:  A `WaveRNN` model to save the parameters and buffers from.
+        optimizer:  An optmizer to save the state of (momentum, etc).
+        name:  If provided, will restore from a checkpoint with the given name.
+            Otherwise, will restore from the latest weights and optimizer state
+            as specified in `paths`.
+        create_if_missing:  If `True`, will create the checkpoint if it doesn't
+            yet exist, as well as update the files specified in `paths` that
+            give the location of the current latest weights and optimizer state.
+            If `False` and the checkpoint doesn't exist, will raise a
+            `FileNotFoundError`.
+    """
+    if name:
+        path_dict = {
+            'w': paths.voc_checkpoints/f'{name}_weights.pyt',
+            'o': paths.voc_checkpoints/f'{name}_optim.pyt',
+        }
+        s = 'named'
     else:
-        device = torch.device('cpu')
-    print('Using device:', device)
+        path_dict = {
+            'w': paths.voc_latest_weights,
+            'o': paths.voc_latest_optim
+        }
+        s = 'latest'
 
-    print('\nInitialising Model...\n')
+    num_exist = sum(p.exists() for p in path_dict.values())
+    if num_exist == 2:
+        # Checkpoint exists
+        print(f'Restoring from {s} checkpoint...')
+        print(f'Loading {s} weights: {path_dict["w"]}')
+        model.load(path_dict['w'])
+        print(f'Loading {s} optimizer state: {path_dict["o"]}')
+        optimizer.load_state_dict(torch.load(path_dict['o']))
+    elif create_if_missing:
+        save_checkpoint(paths, model, optimizer, name=name, is_silent=False)
+    else:
+        raise FileNotFoundError(f'The {s} checkpoint could not be found!')
 
-    # Instantiate WaveRNN Model
-    voc_model = WaveRNN(rnn_dims=hp.voc_rnn_dims,
-                        fc_dims=hp.voc_fc_dims,
-                        bits=hp.bits,
-                        pad=hp.voc_pad,
-                        upsample_factors=hp.voc_upsample_factors,
-                        feat_dims=hp.num_mels,
-                        compute_dims=hp.voc_compute_dims,
-                        res_out_dims=hp.voc_res_out_dims,
-                        res_blocks=hp.voc_res_blocks,
-                        hop_length=hp.hop_length,
-                        sample_rate=hp.sample_rate,
-                        mode=hp.voc_mode).to(device)
-
-    # Check to make sure the hop length is correctly factorised
-    assert np.cumprod(hp.voc_upsample_factors)[-1] == hp.hop_length
-
-    paths = Paths(hp.data_path, hp.voc_model_id, hp.tts_model_id)
-
-    voc_model.restore(paths.voc_latest_weights)
-
-    optimizer = optim.Adam(voc_model.parameters())
-    if os.path.isfile(paths.voc_latest_optim):
-        print(f'Loading Optimizer State: "{paths.voc_latest_optim}"\n')
-        optimizer.load_state_dict(torch.load(paths.voc_latest_optim))
-
-    train_set, test_set = get_vocoder_datasets(paths.data, batch_size, train_gta)
-
-    total_steps = 10_000_000 if force_train else hp.voc_total_steps
-
-    simple_table([('Remaining', str((total_steps - voc_model.get_step())//1000) + 'k Steps'),
-                  ('Batch Size', batch_size),
-                  ('LR', lr),
-                  ('Sequence Len', hp.voc_seq_len),
-                  ('GTA Train', train_gta)])
-
-    loss_func = F.cross_entropy if voc_model.mode == 'RAW' else discretized_mix_logistic_loss
-
-    voc_train_loop(voc_model, loss_func, optimizer, train_set, test_set, lr, total_steps)
-
-    print('Training Complete.')
-    print('To continue training increase voc_total_steps in hparams.py or use --force_train')
 
 if __name__ == "__main__":
     main()

--- a/train_wavernn.py
+++ b/train_wavernn.py
@@ -91,7 +91,7 @@ def main():
     parser.add_argument('--force_train', '-f', action='store_true', help='Forces the model to train past total steps')
     parser.add_argument('--gta', '-g', action='store_true', help='train wavernn on GTA features')
     parser.add_argument('--force_cpu', '-c', action='store_true', help='Forces CPU-only training, even when in CUDA capable environment')
-    parser.add_argument('--hp_file', '-p', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
+    parser.add_argument('--hp_file', metavar='FILE', default='hparams.py', help='The file to use for the hyperparameters')
     args = parser.parse_args()
 
     hp = import_from_file('hparams', args.hp_file)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,31 @@
+# Make it explicit we do it the Python 3 way
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
+import sys
+import torch
+
+# Credit: Ryuichi Yamamoto (https://github.com/r9y9/wavenet_vocoder/blob/1717f145c8f8c0f3f85ccdf346b5209fa2e1c920/train.py#L599)
+# workaround for https://github.com/pytorch/pytorch/issues/15716
+# the idea is to return outputs and replicas explicitly, so that making pytorch
+# not to release the nodes (this is a pytorch bug though)
+
+_output_ref = None
+_replicas_ref = None
+
+def data_parallel_workaround(model, *input):
+    global _output_ref
+    global _replicas_ref
+    device_ids = list(range(torch.cuda.device_count()))
+    output_device = device_ids[0]
+    replicas = torch.nn.parallel.replicate(model, device_ids)
+    # input.shape = (num_args, batch, ...)
+    inputs = torch.nn.parallel.scatter(input, device_ids)
+    # inputs.shape = (num_gpus, num_args, batch/num_gpus, ...)
+    replicas = replicas[:len(inputs)]
+    outputs = torch.nn.parallel.parallel_apply(replicas, inputs)
+    y_hat = torch.nn.parallel.gather(outputs, output_device)
+    _output_ref = outputs
+    _replicas_ref = replicas
+    return y_hat
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -5,6 +5,8 @@ from builtins import *
 import sys
 import torch
 
+from importlib.util import spec_from_file_location, module_from_spec
+
 # Credit: Ryuichi Yamamoto (https://github.com/r9y9/wavenet_vocoder/blob/1717f145c8f8c0f3f85ccdf346b5209fa2e1c920/train.py#L599)
 # Modified by: Ryan Butler (https://github.com/TheButlah)
 # workaround for https://github.com/pytorch/pytorch/issues/15716
@@ -30,3 +32,10 @@ def data_parallel_workaround(model, *input):
     _replicas_ref = replicas
     return y_hat
 
+
+def import_from_file(name, path):
+    """Programmatically imports a module"""
+    spec = spec_from_file_location(name, path)
+    m = module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -6,6 +6,7 @@ import sys
 import torch
 
 from importlib.util import spec_from_file_location, module_from_spec
+from pathlib import Path
 
 # Credit: Ryuichi Yamamoto (https://github.com/r9y9/wavenet_vocoder/blob/1717f145c8f8c0f3f85ccdf346b5209fa2e1c920/train.py#L599)
 # Modified by: Ryan Butler (https://github.com/TheButlah)
@@ -35,7 +36,11 @@ def data_parallel_workaround(model, *input):
 
 def import_from_file(name, path):
     """Programmatically imports a module"""
+    if not Path(path).exists():
+        raise FileNotFoundError('"%s" doesn\'t exist!' % path)
     spec = spec_from_file_location(name, path)
+    if spec is None:
+        raise ValueError('could not load module from "%s"' % path)
     m = module_from_spec(spec)
     spec.loader.exec_module(m)
     return m

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,9 +4,11 @@ from builtins import *
 
 import sys
 import torch
+import re
 
 from importlib.util import spec_from_file_location, module_from_spec
 from pathlib import Path
+from typing import Union
 
 # Credit: Ryuichi Yamamoto (https://github.com/r9y9/wavenet_vocoder/blob/1717f145c8f8c0f3f85ccdf346b5209fa2e1c920/train.py#L599)
 # Modified by: Ryan Butler (https://github.com/TheButlah)
@@ -34,8 +36,64 @@ def data_parallel_workaround(model, *input):
     return y_hat
 
 
-def import_from_file(name, path):
-    """Programmatically imports a module"""
+###### Deal with hparams import that has to be configured at runtime ######
+class __HParams:
+    """Manages the hyperparams pseudo-module"""
+    def __init__(self, path: Union[str, Path]=None):
+        """Constructs the hyperparameters from a path to a python module. If
+        `path` is None, will raise an AttributeError whenever its attributes
+        are accessed. Otherwise, configures self based on `path`."""
+        if path is None:
+            self._configured = False
+        else:
+            self.configure(path)
+
+    def __getattr__(self, item):
+        if not self.is_configured():
+            raise AttributeError("HParams not configured yet. Call self.configure()")
+        else:
+            return super().__getattr__(item)
+
+    def configure(self, path: Union[str, Path]):
+        """Configures hparams by copying over atrributes from a module with the
+        given path. Raises an exception if already configured."""
+        if self.is_configured():
+            raise RuntimeError("Cannot reconfigure hparams!")
+
+        ###### Check for proper path ######
+        if not isinstance(path, Path):
+            path = Path(path).expanduser()
+        if not path.exists():
+            raise FileNotFoundError(f"Could not find hparams file {path}")
+        elif path.suffix != ".py":
+            raise ValueError("`path` must be a python file")
+
+        ###### Load in attributes from module ######
+        m = _import_from_file("hparams", path)
+
+        reg = re.compile(r"^__.+__$")  # Matches magic methods
+        for name, value in m.__dict__.items():
+            if reg.match(name):
+                # Skip builtins
+                continue
+            if name in self.__dict__:
+                # Cannot overwrite already existing attributes
+                raise AttributeError(
+                    f"module at `path` cannot contain attribute {name} as it "
+                    "overwrites an attribute of the same name in utils.hparams")
+            # Fair game to copy over the attribute
+            self.__setattr__(name, value)
+
+        self._configured = True
+
+    def is_configured(self):
+        return self._configured
+
+hparams = __HParams()
+
+
+def _import_from_file(name, path: Path):
+    """Programmatically returns a module object from a filepath"""
     if not Path(path).exists():
         raise FileNotFoundError('"%s" doesn\'t exist!' % path)
     spec = spec_from_file_location(name, path)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
-# Make it explicit we do it the Python 3 way
+# Make it explicit that we do it the Python 3 way
 from __future__ import absolute_import, division, print_function, unicode_literals
 from builtins import *
 
@@ -6,6 +6,7 @@ import sys
 import torch
 
 # Credit: Ryuichi Yamamoto (https://github.com/r9y9/wavenet_vocoder/blob/1717f145c8f8c0f3f85ccdf346b5209fa2e1c920/train.py#L599)
+# Modified by: Ryan Butler (https://github.com/TheButlah)
 # workaround for https://github.com/pytorch/pytorch/issues/15716
 # the idea is to return outputs and replicas explicitly, so that making pytorch
 # not to release the nodes (this is a pytorch bug though)

--- a/utils/checkpoints.py
+++ b/utils/checkpoints.py
@@ -1,0 +1,128 @@
+import torch
+from utils.paths import Paths
+from models.tacotron import Tacotron
+
+
+def get_checkpoint_paths(checkpoint_type: str, paths: Paths):
+    """
+    Returns the correct checkpointing paths
+    depending on whether model is Vocoder or TTS
+
+    Args:
+        checkpoint_type: Either 'voc' or 'tts'
+        paths: Paths object
+    """
+    if checkpoint_type is 'tts':
+        weights_path = paths.tts_latest_weights
+        optim_path = paths.tts_latest_optim
+        checkpoint_path = paths.tts_checkpoints
+    elif checkpoint_type is 'voc':
+        weights_path = paths.voc_latest_weights
+        optim_path = paths.voc_latest_optim
+        checkpoint_path = paths.voc_checkpoints
+    else:
+        raise NotImplementedError
+
+    return weights_path, optim_path, checkpoint_path
+
+
+def save_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, *,
+        name=None, is_silent=False):
+    """Saves the training session to disk.
+
+    Args:
+        paths:  Provides information about the different paths to use.
+        model:  A `Tacotron` or `WaveRNN` model to save the parameters and buffers from.
+        optimizer:  An optmizer to save the state of (momentum, etc).
+        name:  If provided, will name to a checkpoint with the given name. Note
+            that regardless of whether this is provided or not, this function
+            will always update the files specified in `paths` that give the
+            location of the latest weights and optimizer state. Saving
+            a named checkpoint happens in addition to this update.
+    """
+    def helper(path_dict, is_named):
+        s = 'named' if is_named else 'latest'
+        num_exist = sum(p.exists() for p in path_dict.values())
+
+        if num_exist not in (0,2):
+            # Checkpoint broken
+            raise FileNotFoundError(
+                f'We expected either both or no files in the {s} checkpoint to '
+                'exist, but instead we got exactly one!')
+
+        if num_exist == 0:
+            if not is_silent: print(f'Creating {s} checkpoint...')
+            for p in path_dict.values():
+                p.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            if not is_silent: print(f'Saving to existing {s} checkpoint...')
+
+        if not is_silent: print(f'Saving {s} weights: {path_dict["w"]}')
+        model.save(path_dict['w'])
+        if not is_silent: print(f'Saving {s} optimizer state: {path_dict["o"]}')
+        torch.save(optimizer.state_dict(), path_dict['o'])
+
+    weights_path, optim_path, checkpoint_path = \
+        get_checkpoint_paths(checkpoint_type, paths)
+
+    latest_paths = {'w': weights_path, 'o': optim_path}
+    helper(latest_paths, False)
+
+    if name:
+        named_paths = {
+            'w': checkpoint_path/f'{name}_weights.pyt',
+            'o': checkpoint_path/f'{name}_optim.pyt',
+        }
+        helper(named_paths, True)
+
+
+def restore_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, *,
+        name=None, create_if_missing=False):
+    """Restores from a training session saved to disk.
+
+    NOTE: The optimizer's state is placed on the same device as it's model
+    parameters. Therefore, be sure you have done `model.to(device)` before
+    calling this method.
+
+    Args:
+        paths:  Provides information about the different paths to use.
+        model:  A `Tacotron` or `WaveRNN` model to save the parameters and buffers from.
+        optimizer:  An optmizer to save the state of (momentum, etc).
+        name:  If provided, will restore from a checkpoint with the given name.
+            Otherwise, will restore from the latest weights and optimizer state
+            as specified in `paths`.
+        create_if_missing:  If `True`, will create the checkpoint if it doesn't
+            yet exist, as well as update the files specified in `paths` that
+            give the location of the current latest weights and optimizer state.
+            If `False` and the checkpoint doesn't exist, will raise a
+            `FileNotFoundError`.
+    """
+
+    weights_path, optim_path, checkpoint_path = \
+        get_checkpoint_paths(checkpoint_type, paths)
+
+    if name:
+        path_dict = {
+            'w': checkpoint_path/f'{name}_weights.pyt',
+            'o': checkpoint_path/f'{name}_optim.pyt',
+        }
+        s = 'named'
+    else:
+        path_dict = {
+            'w': weights_path,
+            'o': optim_path
+        }
+        s = 'latest'
+
+    num_exist = sum(p.exists() for p in path_dict.values())
+    if num_exist == 2:
+        # Checkpoint exists
+        print(f'Restoring from {s} checkpoint...')
+        print(f'Loading {s} weights: {path_dict["w"]}')
+        model.load(path_dict['w'])
+        print(f'Loading {s} optimizer state: {path_dict["o"]}')
+        optimizer.load_state_dict(torch.load(path_dict['o']))
+    elif create_if_missing:
+        save_checkpoint(checkpoint_type, paths, model, optimizer, name=name, is_silent=False)
+    else:
+        raise FileNotFoundError(f'The {s} checkpoint could not be found!')

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -4,7 +4,7 @@ import torch
 from torch.utils.data import Dataset, DataLoader
 from torch.utils.data.sampler import Sampler
 from utils.dsp import *
-import hparams as hp
+from utils import hparams as hp
 from utils.text import text_to_sequence
 from utils.paths import Paths
 from pathlib import Path

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -129,6 +129,8 @@ def get_tts_datasets(path: Path, batch_size, r):
                            pin_memory=True)
 
     longest = mel_lengths.index(max(mel_lengths))
+
+    # Used to evaluate attention during training process
     attn_example = dataset_ids[longest]
 
     # print(attn_example)

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -6,6 +6,8 @@ from torch.utils.data.sampler import Sampler
 from utils.dsp import *
 import hparams as hp
 from utils.text import text_to_sequence
+from utils.paths import Paths
+from pathlib import Path
 
 
 ###################################################################################
@@ -14,25 +16,25 @@ from utils.text import text_to_sequence
 
 
 class VocoderDataset(Dataset):
-    def __init__(self, ids, path, train_gta=False):
-        self.metadata = ids
-        self.mel_path = f'{path}gta/' if train_gta else f'{path}mel/'
-        self.quant_path = f'{path}quant/'
+    def __init__(self, path: Path, dataset_ids, train_gta=False):
+        self.metadata = dataset_ids
+        self.mel_path = path/'gta' if train_gta else path/'mel'
+        self.quant_path = path/'quant'
 
 
     def __getitem__(self, index):
-        id = self.metadata[index]
-        m = np.load(f'{self.mel_path}{id}.npy')
-        x = np.load(f'{self.quant_path}{id}.npy')
+        item_id = self.metadata[index]
+        m = np.load(self.mel_path/f'{item_id}.npy')
+        x = np.load(self.quant_path/f'{item_id}.npy')
         return m, x
 
     def __len__(self):
         return len(self.metadata)
 
 
-def get_vocoder_datasets(path, batch_size, train_gta):
+def get_vocoder_datasets(path: Path, batch_size, train_gta):
 
-    with open(f'{path}dataset.pkl', 'rb') as f:
+    with open(path/'dataset.pkl', 'rb') as f:
         dataset = pickle.load(f)
 
     dataset_ids = [x[0] for x in dataset]
@@ -43,8 +45,8 @@ def get_vocoder_datasets(path, batch_size, train_gta):
     test_ids = dataset_ids[-hp.voc_test_samples:]
     train_ids = dataset_ids[:-hp.voc_test_samples]
 
-    train_dataset = VocoderDataset(train_ids, path, train_gta)
-    test_dataset = VocoderDataset(test_ids, path, train_gta)
+    train_dataset = VocoderDataset(path, train_ids, train_gta)
+    test_dataset = VocoderDataset(path, test_ids, train_gta)
 
     train_set = DataLoader(train_dataset,
                            collate_fn=collate_vocoder,
@@ -96,20 +98,20 @@ def collate_vocoder(batch):
 ###################################################################################
 
 
-def get_tts_dataset(path, batch_size, r):
+def get_tts_datasets(path: Path, batch_size, r):
 
-    with open(f'{path}dataset.pkl', 'rb') as f:
+    with open(path/'dataset.pkl', 'rb') as f:
         dataset = pickle.load(f)
 
     dataset_ids = []
     mel_lengths = []
 
-    for (id, len) in dataset:
+    for (item_id, len) in dataset:
         if len <= hp.tts_max_mel_len:
-            dataset_ids += [id]
+            dataset_ids += [item_id]
             mel_lengths += [len]
 
-    with open(f'{path}text_dict.pkl', 'rb') as f:
+    with open(path/'text_dict.pkl', 'rb') as f:
         text_dict = pickle.load(f)
 
     train_dataset = TTSDataset(path, dataset_ids, text_dict)
@@ -135,17 +137,17 @@ def get_tts_dataset(path, batch_size, r):
 
 
 class TTSDataset(Dataset):
-    def __init__(self, path, dataset_ids, text_dict):
+    def __init__(self, path: Path, dataset_ids, text_dict):
         self.path = path
         self.metadata = dataset_ids
         self.text_dict = text_dict
 
     def __getitem__(self, index):
-        id = self.metadata[index]
-        x = text_to_sequence(self.text_dict[id], hp.tts_cleaner_names)
-        mel = np.load(f'{self.path}mel/{id}.npy')
+        item_id = self.metadata[index]
+        x = text_to_sequence(self.text_dict[item_id], hp.tts_cleaner_names)
+        mel = np.load(self.path/'mel'/f'{item_id}.npy')
         mel_len = mel.shape[-1]
-        return x, mel, id, mel_len
+        return x, mel, item_id, mel_len
 
     def __len__(self):
         return len(self.metadata)
@@ -216,17 +218,3 @@ class BinnedLengthSampler(Sampler):
 
     def __len__(self):
         return len(self.idx)
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/utils/display.py
+++ b/utils/display.py
@@ -84,7 +84,7 @@ def time_since(started):
 def save_attention(attn, path):
     fig = plt.figure(figsize=(12, 6))
     plt.imshow(attn.T, interpolation='nearest', aspect='auto')
-    fig.savefig(f'{path}.png', bbox_inches='tight')
+    fig.savefig(path.parent/f'{path.stem}.png', bbox_inches='tight')
     plt.close(fig)
 
 
@@ -97,7 +97,7 @@ def save_spectrogram(M, path, length=None):
     plt.close(fig)
 
 
-def plot(array): 
+def plot(array):
     mpl.interactive(True)
     fig = plt.figure(figsize=(30, 5))
     ax = fig.add_subplot(111)

--- a/utils/display.py
+++ b/utils/display.py
@@ -1,3 +1,5 @@
+import matplotlib as mpl
+mpl.use('agg')  # Use non-interactive backend by default
 import matplotlib.pyplot as plt
 import time
 import numpy as np
@@ -96,6 +98,7 @@ def save_spectrogram(M, path, length=None):
 
 
 def plot(array): 
+    mpl.interactive(True)
     fig = plt.figure(figsize=(30, 5))
     ax = fig.add_subplot(111)
     ax.xaxis.label.set_color('grey')
@@ -105,11 +108,14 @@ def plot(array):
     ax.tick_params(axis='x', colors='grey', labelsize=23)
     ax.tick_params(axis='y', colors='grey', labelsize=23)
     plt.plot(array)
+    mpl.interactive(False)
 
 
 def plot_spec(M):
+    mpl.interactive(True)
     M = np.flip(M, axis=0)
     plt.figure(figsize=(18,4))
     plt.imshow(M, interpolation='nearest', aspect='auto')
     plt.show()
+    mpl.interactive(False)
 

--- a/utils/dsp.py
+++ b/utils/dsp.py
@@ -14,6 +14,7 @@ def float_2_label(x, bits):
     x = (x + 1.) * (2**bits - 1) / 2
     return x.clip(0, 2**bits - 1)
 
+
 def load_wav(path):
     return librosa.load(path, sr=hp.sample_rate)[0]
 
@@ -38,8 +39,6 @@ def encode_16bits(x):
 
 
 mel_basis = None
-
-
 def linear_to_mel(spectrogram):
     global mel_basis
     if mel_basis is None:

--- a/utils/dsp.py
+++ b/utils/dsp.py
@@ -1,7 +1,7 @@
 import math
 import numpy as np
 import librosa
-import hparams as hp
+from utils import hparams as hp
 from scipy.signal import lfilter
 
 

--- a/utils/dsp.py
+++ b/utils/dsp.py
@@ -38,17 +38,14 @@ def encode_16bits(x):
     return np.clip(x * 2**15, -2**15, 2**15 - 1).astype(np.int16)
 
 
-mel_basis = None
 def linear_to_mel(spectrogram):
-    global mel_basis
-    if mel_basis is None:
-        mel_basis = build_mel_basis()
-    return np.dot(mel_basis, spectrogram)
+    librosa.feature.melspectrogram(
+        S=spectrogram, sr=hp.sample_rate, n_fft=hp.n_fft, n_mels=hp.num_mels, fmin=hp.fmin)
 
-
+'''
 def build_mel_basis():
     return librosa.filters.mel(hp.sample_rate, hp.n_fft, n_mels=hp.num_mels, fmin=hp.fmin)
-
+'''
 
 def normalize(S):
     return np.clip((S - hp.min_level_db) / -hp.min_level_db, 0, 1)
@@ -79,7 +76,9 @@ def melspectrogram(y):
 
 
 def stft(y):
-    return librosa.stft(y=y, n_fft=hp.n_fft, hop_length=hp.hop_length, win_length=hp.win_length)
+    return librosa.stft(
+        y=y, sr=hp.sample_rate,
+        n_fft=hp.n_fft, hop_length=hp.hop_length, win_length=hp.win_length)
 
 
 def pre_emphasis(x):
@@ -102,4 +101,17 @@ def decode_mu_law(y, mu, from_labels=True):
     mu = mu - 1
     x = np.sign(y) / mu * ((1 + mu) ** np.abs(y) - 1)
     return x
+
+def reconstruct_waveform(mel, n_iter=32):
+    """Uses Griffin-Lim phase reconstruction to convert from a normalized
+    mel spectrogram back into a waveform."""
+    denormalized = denormalize(mel)
+    amp_mel = db_to_amp(denormalized)
+    S = librosa.feature.inverse.mel_to_stft(
+        amp_mel, power=1, sr=hp.sample_rate,
+        n_fft=hp.n_fft, fmin=hp.fmin)
+    wav = librosa.core.griffinlim(
+        S, n_iter=n_iter,
+        hop_length=hp.hop_length, win_length=hp.win_length)
+    return wav
 

--- a/utils/dsp.py
+++ b/utils/dsp.py
@@ -39,7 +39,7 @@ def encode_16bits(x):
 
 
 def linear_to_mel(spectrogram):
-    librosa.feature.melspectrogram(
+    return librosa.feature.melspectrogram(
         S=spectrogram, sr=hp.sample_rate, n_fft=hp.n_fft, n_mels=hp.num_mels, fmin=hp.fmin)
 
 '''
@@ -77,7 +77,7 @@ def melspectrogram(y):
 
 def stft(y):
     return librosa.stft(
-        y=y, sr=hp.sample_rate,
+        y=y,
         n_fft=hp.n_fft, hop_length=hp.hop_length, win_length=hp.win_length)
 
 

--- a/utils/files.py
+++ b/utils/files.py
@@ -1,7 +1,6 @@
-import glob
+from pathlib import Path
+from typing import Union
 
-def get_files(path, extension='.wav'):
-    filenames = []
-    for filename in glob.iglob(f'{path}/**/*{extension}', recursive=True):
-        filenames += [filename]
-    return filenames
+def get_files(path: Union[str, Path], extension='.wav'):
+    if isinstance(path, str): path = Path(path).expanduser().resolve()
+    return list(path.rglob(f'*{extension}'))

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -6,13 +6,13 @@ class Paths:
     """Manages and configures the paths used by WaveRNN, Tacotron, and the data."""
     def __init__(self, data_path, voc_id, tts_id):
         self.base = Path(__file__).parent.parent.expanduser().resolve()
-        
+
         # Data Paths
         self.data = Path(data_path).expanduser().resolve()
         self.quant = self.data/'quant'
         self.mel = self.data/'mel'
         self.gta = self.data/'gta'
-        
+
         # WaveRNN/Vocoder Paths
         self.voc_checkpoints = self.base/'checkpoints'/f'{voc_id}.wavernn'
         self.voc_latest_weights = self.voc_checkpoints/'latest_weights.pyt'
@@ -20,7 +20,7 @@ class Paths:
         self.voc_output = self.base/'model_outputs'/f'{voc_id}.wavernn'
         self.voc_step = self.voc_checkpoints/'step.npy'
         self.voc_log = self.voc_checkpoints/'log.txt'
-        
+
         # Tactron/TTS Paths
         self.tts_checkpoints = self.base/'checkpoints'/f'{tts_id}.tacotron'
         self.tts_latest_weights = self.tts_checkpoints/'latest_weights.pyt'
@@ -30,6 +30,7 @@ class Paths:
         self.tts_log = self.tts_checkpoints/'log.txt'
         self.tts_attention = self.tts_checkpoints/'attention'
         self.tts_mel_plot = self.tts_checkpoints/'mel_plots'
+
         self.create_paths()
 
     def create_paths(self):
@@ -43,11 +44,11 @@ class Paths:
         os.makedirs(self.tts_output, exist_ok=True)
         os.makedirs(self.tts_attention, exist_ok=True)
         os.makedirs(self.tts_mel_plot, exist_ok=True)
-    
+
     def get_tts_named_weights(self, name):
         """Gets the path for the weights in a named tts checkpoint."""
         return self.tts_checkpoints/f'{name}_weights.pyt'
-    
+
     def get_tts_named_optim(self, name):
         """Gets the path for the optimizer state in a named tts checkpoint."""
         return self.tts_checkpoints/f'{name}_optim.pyt'
@@ -55,9 +56,9 @@ class Paths:
     def get_voc_named_weights(self, name):
         """Gets the path for the weights in a named voc checkpoint."""
         return self.voc_checkpoints/f'{name}_weights.pyt'
-    
+
     def get_voc_named_optim(self, name):
         """Gets the path for the optimizer state in a named voc checkpoint."""
         return self.voc_checkpoints/f'{name}_optim.pyt'
-    
+
 

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,29 +1,35 @@
 import os
+from pathlib import Path
 
 
 class Paths:
+    """Manages and configures the paths used by WaveRNN, Tacotron, and the data."""
     def __init__(self, data_path, voc_id, tts_id):
+        self.base = Path(__file__).parent.parent.expanduser().resolve()
+        
         # Data Paths
-        self.data = f'{data_path}{voc_id}/'
-        self.quant = f'{self.data}quant/'
-        self.mel = f'{self.data}mel/'
-        self.gta = f'{self.data}gta/'
+        self.data = Path(data_path).expanduser().resolve()
+        self.quant = self.data/'quant'
+        self.mel = self.data/'mel'
+        self.gta = self.data/'gta'
+        
         # WaveRNN/Vocoder Paths
-        self.voc_checkpoints = f'checkpoints/{voc_id}.wavernn/'
-        self.voc_latest_weights = f'{self.voc_checkpoints}latest_weights.pyt'
-        self.voc_latest_optim = f'{self.voc_checkpoints}latest_optim.pyt'
-        self.voc_output = f'model_outputs/{voc_id}.wavernn/'
-        self.voc_step = f'{self.voc_checkpoints}/step.npy'
-        self.voc_log = f'{self.voc_checkpoints}log.txt'
+        self.voc_checkpoints = self.base/'checkpoints'/f'{voc_id}.wavernn'
+        self.voc_latest_weights = self.voc_checkpoints/'latest_weights.pyt'
+        self.voc_latest_optim = self.voc_checkpoints/'latest_optim.pyt'
+        self.voc_output = self.base/'model_outputs'/f'{voc_id}.wavernn'
+        self.voc_step = self.voc_checkpoints/'step.npy'
+        self.voc_log = self.voc_checkpoints/'log.txt'
+        
         # Tactron/TTS Paths
-        self.tts_checkpoints = f'checkpoints/{tts_id}.tacotron/'
-        self.tts_latest_weights = f'{self.tts_checkpoints}latest_weights.pyt'
-        self.tts_latest_optim = f'{self.tts_checkpoints}latest_optim.pyt'
-        self.tts_output = f'model_outputs/{tts_id}.tts/'
-        self.tts_step = f'{self.tts_checkpoints}/step.npy'
-        self.tts_log = f'{self.tts_checkpoints}log.txt'
-        self.tts_attention = f'{self.tts_checkpoints}/attention/'
-        self.tts_mel_plot = f'{self.tts_checkpoints}/mel_plots/'
+        self.tts_checkpoints = self.base/'checkpoints'/f'{tts_id}.tacotron'
+        self.tts_latest_weights = self.tts_checkpoints/'latest_weights.pyt'
+        self.tts_latest_optim = self.tts_checkpoints/'latest_optim.pyt'
+        self.tts_output = self.base/'model_outputs'/f'{tts_id}.tacotron'
+        self.tts_step = self.tts_checkpoints/'step.npy'
+        self.tts_log = self.tts_checkpoints/'log.txt'
+        self.tts_attention = self.tts_checkpoints/'attention'
+        self.tts_mel_plot = self.tts_checkpoints/'mel_plots'
         self.create_paths()
 
     def create_paths(self):
@@ -37,4 +43,21 @@ class Paths:
         os.makedirs(self.tts_output, exist_ok=True)
         os.makedirs(self.tts_attention, exist_ok=True)
         os.makedirs(self.tts_mel_plot, exist_ok=True)
+    
+    def get_tts_named_weights(self, name):
+        """Gets the path for the weights in a named tts checkpoint."""
+        return self.tts_checkpoints/f'{name}_weights.pyt'
+    
+    def get_tts_named_optim(self, name):
+        """Gets the path for the optimizer state in a named tts checkpoint."""
+        return self.tts_checkpoints/f'{name}_optim.pyt'
+
+    def get_voc_named_weights(self, name):
+        """Gets the path for the weights in a named voc checkpoint."""
+        return self.voc_checkpoints/f'{name}_weights.pyt'
+    
+    def get_voc_named_optim(self, name):
+        """Gets the path for the optimizer state in a named voc checkpoint."""
+        return self.voc_checkpoints/f'{name}_optim.pyt'
+    
 

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -11,12 +11,14 @@ class Paths:
         # WaveRNN/Vocoder Paths
         self.voc_checkpoints = f'checkpoints/{voc_id}.wavernn/'
         self.voc_latest_weights = f'{self.voc_checkpoints}latest_weights.pyt'
+        self.voc_latest_optim = f'{self.voc_checkpoints}latest_optim.pyt'
         self.voc_output = f'model_outputs/{voc_id}.wavernn/'
         self.voc_step = f'{self.voc_checkpoints}/step.npy'
         self.voc_log = f'{self.voc_checkpoints}log.txt'
         # Tactron/TTS Paths
         self.tts_checkpoints = f'checkpoints/{tts_id}.tacotron/'
         self.tts_latest_weights = f'{self.tts_checkpoints}latest_weights.pyt'
+        self.tts_latest_optim = f'{self.tts_checkpoints}latest_optim.pyt'
         self.tts_output = f'model_outputs/{tts_id}.tts/'
         self.tts_step = f'{self.tts_checkpoints}/step.npy'
         self.tts_log = f'{self.tts_checkpoints}log.txt'

--- a/utils/text/recipes.py
+++ b/utils/text/recipes.py
@@ -1,8 +1,9 @@
 from utils.files import get_files
+from pathlib import Path
+from typing import Union
 
 
-def ljspeech(path) :
-
+def ljspeech(path: Union[str, Path]):
     csv_file = get_files(path, extension='.csv')
 
     assert len(csv_file) == 1


### PR DESCRIPTION
Follows up on PR #109. 

Added the following features:
- Multi-GPU Training.
- Added Griffin-Lim as a baseline vocoder
- Restoring checkpoints now also accounts for optimizer state, making it safe to save and restore training sessions
- `hparams` module can be specified via argument to facilitate testing with different sets of hyperparameters
- Vocoder and Tacotron both use gradient clipping by default now, and can be configured in `hparams`

Refactored the following:
- Codebase now uses pathlib to be more platform independent and nice to use
- Paths module is now clearer and less ambiguous by using pathlib, no longer need to worry if the paths should end in `/` or not
- More things that should have been in PyTorch buffers are now in buffers
- Checkpoint saving and restoring completely changed, explicitly delegates the responsibility of training-related state to the training scripts, and model-related state to the models.
- Specifying training vs eval mode uses PyTorch conventions

Fixed the following bugs:
- Issue where saving spectrograms via matplotlib was using interactive backend, requiring X11 to be running.
- Missing imports
- Other bugs

~**Please vet this code! It's not yet thoroughly tested.**~

Another caveat to note: The notebooks are now very very outdated. I haven't touched them, and they appear to use their own code so none of this should affect them.