### PR TITLE
Enables using newer versions of librosa

### DIFF
--- a/notebooks/NB4a - Alternative Model (Preprocessing).ipynb
+++ b/notebooks/NB4a - Alternative Model (Preprocessing).ipynb
@@ -20,7 +20,8 @@
     "import math, pickle, os, glob\n",
     "import numpy as np\n",
     "from utils.display import *\n",
-    "from utils.dsp import *"
+    "from utils.dsp import *\n",
+    "import soundfile as sf"
    ]
   },
   {

--- a/notebooks/NB4a - Alternative Model (Preprocessing).ipynb
+++ b/notebooks/NB4a - Alternative Model (Preprocessing).ipynb
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "librosa.output.write_wav(DATA_PATH + 'test_quant.wav', x, sr=sample_rate)"
+    "sf.write(DATA_PATH + 'test_quant.wav', x, sample_rate, subtype='PCM_24')"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy==1.16.2
-librosa==0.6.3
+librosa
+soundfile
 matplotlib
 unidecode
 inflect

--- a/utils/dsp.py
+++ b/utils/dsp.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 import librosa
+import soundfile as sf
 from utils import hparams as hp
 from scipy.signal import lfilter
 
@@ -20,7 +21,7 @@ def load_wav(path):
 
 
 def save_wav(x, path):
-    librosa.output.write_wav(path, x.astype(np.float32), sr=hp.sample_rate)
+    sf.write(path, x.astype(np.float32), hp.sample_rate, subtype='PCM_24')
 
 
 def split_signal(x):


### PR DESCRIPTION
Since [`librosa.output` has been removed](https://librosa.org/doc/latest/changelog.html), this uses instead PySoundFile [as suggested in the librosa documentation](https://librosa.org/doc/latest/ioformats.html). Tested and works with librosa 0.8.0.