### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy==1.16.2
 librosa==0.6.3
+numba==0.48
 matplotlib
 unidecode
 inflect


### PR DESCRIPTION
This is a fix for this version of librosa accidentally installing a version of numba that is too new (numba==0.51.2) and breaking.

https://github.com/librosa/librosa/issues/1160