### PR TITLE
add mixed precision training

### DIFF
--- a/hparams.py
+++ b/hparams.py
@@ -53,6 +53,7 @@ voc_test_samples = 50               # How many unseen samples to put aside for t
 voc_pad = 2                         # this will pad the input so that the resnet can 'see' wider than input length
 voc_seq_len = hop_length * 5        # must be a multiple of hop_length
 voc_clip_grad_norm = 4              # set to None if no gradient clipping needed
+voc_use_mixed_precision = True      # Enable mixed precision
 
 # Generating / Synthesizing
 voc_gen_batched = True              # very fast (realtime+) single utterance batched generation
@@ -91,7 +92,7 @@ tts_bin_lengths = True              # bins the spectrogram lengths before sampli
 tts_clip_grad_norm = 1.0            # clips the gradient norm to prevent explosion - set to None if not needed
 tts_checkpoint_every = 2_000        # checkpoints the model every X steps
 # TODO: tts_phoneme_prob = 0.0              # [0 <-> 1] probability for feeding model phonemes vrs graphemes
-
+tts_use_mixed_precision = False     # Enable mixed precision
 
 # ------------------------------------------------------------------------------------------------------------------#
 

--- a/utils/checkpoints.py
+++ b/utils/checkpoints.py
@@ -15,18 +15,20 @@ def get_checkpoint_paths(checkpoint_type: str, paths: Paths):
     if checkpoint_type is 'tts':
         weights_path = paths.tts_latest_weights
         optim_path = paths.tts_latest_optim
+        scaler_path = paths.tts_latest_scaler
         checkpoint_path = paths.tts_checkpoints
     elif checkpoint_type is 'voc':
         weights_path = paths.voc_latest_weights
         optim_path = paths.voc_latest_optim
+        scaler_path = paths.voc_latest_scaler
         checkpoint_path = paths.voc_checkpoints
     else:
         raise NotImplementedError
 
-    return weights_path, optim_path, checkpoint_path
+    return weights_path, optim_path, scaler_path, checkpoint_path
 
 
-def save_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, *,
+def save_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, scaler, *,
         name=None, is_silent=False):
     """Saves the training session to disk.
 
@@ -34,17 +36,18 @@ def save_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, *,
         paths:  Provides information about the different paths to use.
         model:  A `Tacotron` or `WaveRNN` model to save the parameters and buffers from.
         optimizer:  An optmizer to save the state of (momentum, etc).
+        scaler: A scaler to save the state of (mixed precision training).
         name:  If provided, will name to a checkpoint with the given name. Note
             that regardless of whether this is provided or not, this function
             will always update the files specified in `paths` that give the
             location of the latest weights and optimizer state. Saving
             a named checkpoint happens in addition to this update.
     """
-    def helper(path_dict, is_named):
+    def helper(required_path_dict, optional_path_dict, is_named):
         s = 'named' if is_named else 'latest'
-        num_exist = sum(p.exists() for p in path_dict.values())
+        num_exist = sum(p.exists() for p in required_path_dict.values())
 
-        if num_exist not in (0,2):
+        if num_exist not in (0,len(required_path_dict)):
             # Checkpoint broken
             raise FileNotFoundError(
                 f'We expected either both or no files in the {s} checkpoint to '
@@ -52,31 +55,45 @@ def save_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, *,
 
         if num_exist == 0:
             if not is_silent: print(f'Creating {s} checkpoint...')
-            for p in path_dict.values():
+            for p in required_path_dict.values():
                 p.parent.mkdir(parents=True, exist_ok=True)
         else:
             if not is_silent: print(f'Saving to existing {s} checkpoint...')
 
-        if not is_silent: print(f'Saving {s} weights: {path_dict["w"]}')
-        model.save(path_dict['w'])
-        if not is_silent: print(f'Saving {s} optimizer state: {path_dict["o"]}')
-        torch.save(optimizer.state_dict(), path_dict['o'])
+        if not is_silent: print(f'Saving {s} weights: {required_path_dict["w"]}')
+        model.save(required_path_dict['w'])
+        if not is_silent: print(f'Saving {s} optimizer state: {required_path_dict["o"]}')
+        torch.save(optimizer.state_dict(), required_path_dict['o'])
+        
+        for p in optional_path_dict.values():
+            if not p.exists():
+                p.parent.mkdir(parents=True, exist_ok=True)
+        
+        if scaler:
+            if not is_silent: print(f'Saving {s} scaler state: {optional_path_dict["s"]}')
+            torch.save(scaler.state_dict(), optional_path_dict['s'])
 
-    weights_path, optim_path, checkpoint_path = \
+    weights_path, optim_path, scaler_path, checkpoint_path = \
         get_checkpoint_paths(checkpoint_type, paths)
 
-    latest_paths = {'w': weights_path, 'o': optim_path}
-    helper(latest_paths, False)
+    latest_required_paths = {'w': weights_path, 'o': optim_path}
+    latest_optional_paths = {'s': scaler_path}
+    
+    helper(latest_required_paths, latest_optional_paths, False)
 
     if name:
-        named_paths = {
+        named_required_paths = {
             'w': checkpoint_path/f'{name}_weights.pyt',
             'o': checkpoint_path/f'{name}_optim.pyt',
         }
-        helper(named_paths, True)
+        
+        named_optional_paths = {
+            's': checkpoint_path/f'{name}_scaler.pyt',
+        }
+        helper(named_required_paths, named_optional_paths, True)
 
 
-def restore_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, *,
+def restore_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, scaler, *,
         name=None, create_if_missing=False):
     """Restores from a training session saved to disk.
 
@@ -88,6 +105,7 @@ def restore_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, *,
         paths:  Provides information about the different paths to use.
         model:  A `Tacotron` or `WaveRNN` model to save the parameters and buffers from.
         optimizer:  An optmizer to save the state of (momentum, etc).
+        scaler: A scaler to load the state to (mixed precision training).
         name:  If provided, will restore from a checkpoint with the given name.
             Otherwise, will restore from the latest weights and optimizer state
             as specified in `paths`.
@@ -98,31 +116,39 @@ def restore_checkpoint(checkpoint_type: str, paths: Paths, model, optimizer, *,
             `FileNotFoundError`.
     """
 
-    weights_path, optim_path, checkpoint_path = \
+    weights_path, optim_path, scaler_path, checkpoint_path = \
         get_checkpoint_paths(checkpoint_type, paths)
 
     if name:
         path_dict = {
             'w': checkpoint_path/f'{name}_weights.pyt',
             'o': checkpoint_path/f'{name}_optim.pyt',
+            's': checkpoint_path/f'{name}_scaler.pyt',
         }
         s = 'named'
     else:
-        path_dict = {
+        required_path_dict = {
             'w': weights_path,
             'o': optim_path
         }
+        optional_path_dict = {
+            's': scaler_path
+        }
         s = 'latest'
 
-    num_exist = sum(p.exists() for p in path_dict.values())
-    if num_exist == 2:
+    num_exist = sum(p.exists() for p in required_path_dict.values())
+    if num_exist == len(required_path_dict):
         # Checkpoint exists
         print(f'Restoring from {s} checkpoint...')
-        print(f'Loading {s} weights: {path_dict["w"]}')
-        model.load(path_dict['w'])
-        print(f'Loading {s} optimizer state: {path_dict["o"]}')
-        optimizer.load_state_dict(torch.load(path_dict['o']))
+        print(f'Loading {s} weights: {required_path_dict["w"]}')
+        model.load(required_path_dict['w'])
+        print(f'Loading {s} optimizer state: {required_path_dict["o"]}')
+        optimizer.load_state_dict(torch.load(required_path_dict['o']))
+        
+        if scaler and optional_path_dict["s"].exists():
+            print(f'Loading {s} scaler state: {optional_path_dict["s"]}')
+            scaler.load_state_dict(torch.load(optional_path_dict['s']))
     elif create_if_missing:
-        save_checkpoint(checkpoint_type, paths, model, optimizer, name=name, is_silent=False)
+        save_checkpoint(checkpoint_type, paths, model, optimizer, scaler, name=name, is_silent=False)
     else:
         raise FileNotFoundError(f'The {s} checkpoint could not be found!')

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -17,6 +17,7 @@ class Paths:
         self.voc_checkpoints = self.base/'checkpoints'/f'{voc_id}.wavernn'
         self.voc_latest_weights = self.voc_checkpoints/'latest_weights.pyt'
         self.voc_latest_optim = self.voc_checkpoints/'latest_optim.pyt'
+        self.voc_latest_scaler = self.voc_checkpoints/'latest_scaler.pyt'
         self.voc_output = self.base/'model_outputs'/f'{voc_id}.wavernn'
         self.voc_step = self.voc_checkpoints/'step.npy'
         self.voc_log = self.voc_checkpoints/'log.txt'
@@ -25,6 +26,7 @@ class Paths:
         self.tts_checkpoints = self.base/'checkpoints'/f'{tts_id}.tacotron'
         self.tts_latest_weights = self.tts_checkpoints/'latest_weights.pyt'
         self.tts_latest_optim = self.tts_checkpoints/'latest_optim.pyt'
+        self.tts_latest_scaler = self.tts_checkpoints/'latest_scaler.pyt'
         self.tts_output = self.base/'model_outputs'/f'{tts_id}.tacotron'
         self.tts_step = self.tts_checkpoints/'step.npy'
         self.tts_log = self.tts_checkpoints/'log.txt'
@@ -52,6 +54,10 @@ class Paths:
     def get_tts_named_optim(self, name):
         """Gets the path for the optimizer state in a named tts checkpoint."""
         return self.tts_checkpoints/f'{name}_optim.pyt'
+        
+    def get_tts_named_scaler(self, name):
+        """Gets the path for the scaler state in a named tts checkpoint."""
+        return self.tts_checkpoints/f'{name}_scaler.pyt'
 
     def get_voc_named_weights(self, name):
         """Gets the path for the weights in a named voc checkpoint."""
@@ -60,5 +66,9 @@ class Paths:
     def get_voc_named_optim(self, name):
         """Gets the path for the optimizer state in a named voc checkpoint."""
         return self.voc_checkpoints/f'{name}_optim.pyt'
+        
+    def get_voc_named_scaler(self, name):
+        """Gets the path for the scaler state in a named voc checkpoint."""
+        return self.voc_checkpoints/f'{name}_scaler.pyt'
 
 


### PR DESCRIPTION
This pull request adds option to enable mixed precision training by using [torch.cuda.amp](https://pytorch.org/docs/stable/amp.html) package.

I can't figure out why but for Tacotron, mixed precision decreases training speed so I recommend to keep `tts_use_mixed_precision` opion disabled. For WaveRNN I had  ~30% training speed boost (2.5 steps/sec vs 3.2 steps/sec on RTX2080s) and reduced GPU memory usage by ~40% (3.37GB vs 2.43GB) (`voc_use_mixed_precision` is enabled by default).